### PR TITLE
[FFM-7812]: Fix parsing of JSON for large integer values

### DIFF
--- a/force-app/main/classes/FFModelsFeatures.cls
+++ b/force-app/main/classes/FFModelsFeatures.cls
@@ -103,9 +103,9 @@ public abstract class FFModelsFeatures {
         //OPTIONAL
         public List<Clause> rules { get; set; }
         //OPTIONAL
-        public Integer createdAt { get; set; }
+        public Long createdAt { get; set; }
         //OPTIONAL
-        public Integer modifiedAt { get; set; }
+        public Long modifiedAt { get; set; }
         //OPTIONAL
         public Integer version { get; set; }
     } 


### PR DESCRIPTION
When parsing the Target Segment JSON, there is an JSON Exception when the `createdAt` and `modifiedAt` values are greater than the allowable maximum Integer. Changing this value type to Long should address the parsing issues.