### PR TITLE
[FFM-9071] - Rewrite flag/targetsegment cache

### DIFF
--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -17,7 +17,7 @@ public class FFAuthServiceCached implements FFAuthService {
     }
 
     private void updateAuthInCache(FFModels.AuthInfo claims) {
-        this.config.cache.put(this.getAuthCacheKey(), new Map<String, String>{
+        this.config.cache.putAuth(this.getAuthCacheKey(), new Map<String, String>{
             CACHE_KEY_ENVIRONMENT => claims.environmentUUID,
             CACHE_KEY_CLUSTER => claims.cluster,
             CACHE_KEY_JWT => claims.authToken
@@ -25,14 +25,14 @@ public class FFAuthServiceCached implements FFAuthService {
     }
 
     private FFModels.AuthInfo claimsFromCache() {
-        Map<String, String> authData = (Map<String, String>)this.config.cache.get(this.getAuthCacheKey());
+        Map<String, String> authData = (Map<String, String>)this.config.cache.getAuth(this.getAuthCacheKey());
         if(authData == null) return null;
         System.debug('Loading authentication data from cache');
         return new FFModels.AuthInfo(authData.get(CACHE_KEY_JWT), authData.get(CACHE_KEY_ENVIRONMENT), authData.get(CACHE_KEY_CLUSTER));
     }
 
     private String getAuthCacheKey() {
-        return FFCacheKeys.getAuthCacheKey(this.config.cache, this.sdkKey);
+        return FFCacheKeys.getAuthCacheKey(this.sdkKey);
     }
 
     public FFModels.AuthInfo authenticate() {

--- a/force-app/main/classes/FFCache.cls
+++ b/force-app/main/classes/FFCache.cls
@@ -1,10 +1,12 @@
 public interface FFCache {
 
-    void put(String key, Object value, Integer ttl);
+    void putFeatures(List<FFModelsFeatures.FeatureConfig> features, Integer ttl);
+    void putSegments(List<FFModelsFeatures.TargetSegment> segments, Integer ttl);
+    void putAuth(String key, Map<String, String> authData, Integer ttl);
 
-    Object get(String key);
+    List<FFModelsFeatures.FeatureConfig> getFeatures();
+    List<FFModelsFeatures.TargetSegment> getSegments();
+    Map<String, String> getAuth(String key);
 
     String getCacheNamespace();
-
-    String getCachePartition();
 }

--- a/force-app/main/classes/FFCacheKeys.cls
+++ b/force-app/main/classes/FFCacheKeys.cls
@@ -1,19 +1,7 @@
 public abstract class FFCacheKeys {
-    
-    public static String cachePrefix(FFCache cache) {
-        return cache.getCacheNamespace() + '.' + cache.getCachePartition();
-    }
 
-    public static String getAuthCacheKey(FFCache cache, String sdkKey) {
-        return FFCacheKeys.cachePrefix(cache) + '.auth' + sdkKey.replaceAll('-', '');
-    }
-
-    public static String getFeatureConfigsKey(FFCache cache) {
-        return FFCacheKeys.cachePrefix(cache) + '.featureConfigs';
-    }
-
-    public static String getTargetSegmentsKey(FFCache cache) {
-        return FFCacheKeys.cachePrefix(cache) + '.targetSegments';
+    public static String getAuthCacheKey(String sdkKey) {
+        return sdkKey.replaceAll('-', '');
     }
 }
 

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -39,17 +39,17 @@ public class FFClient {
     public void updateCache() {
         FFCache cache = this.config.cache;
         List<FFModelsFeatures.FeatureConfig> features = this.api.getFeatureConfigs(this.envAndClusterRequestParams());
-        cache.put(FFCacheKeys.getFeatureConfigsKey(cache), features, this.config.featureConfigTimeToLive);
+        cache.putFeatures(features, this.config.featureConfigTimeToLive);
         List<FFModelsFeatures.TargetSegment> segments = this.api.getTargetSegments(this.envAndClusterRequestParams());
-        cache.put(FFCacheKeys.getTargetSegmentsKey(cache), segments, this.config.featureConfigTimeToLive);
+        cache.putSegments(segments, this.config.featureConfigTimeToLive);
     }
 
     private List<FFModelsFeatures.FeatureConfig> getFeatureConfigs() {
         FFCache cache = this.config.cache;
-        List<FFModelsFeatures.FeatureConfig> featureConfigs = (List<FFModelsFeatures.FeatureConfig>) cache.get(FFCacheKeys.getFeatureConfigsKey(cache));
+        List<FFModelsFeatures.FeatureConfig> featureConfigs = (List<FFModelsFeatures.FeatureConfig>) cache.getFeatures();
         if(featureConfigs == null) {
             List<FFModelsFeatures.FeatureConfig> updated = this.api.getFeatureConfigs(this.envAndClusterRequestParams());
-            cache.put(FFCacheKeys.getFeatureConfigsKey(cache), updated, this.config.featureConfigTimeToLive);
+            cache.putFeatures(updated, this.config.featureConfigTimeToLive);
             return updated;
         }
         return featureConfigs;
@@ -57,10 +57,10 @@ public class FFClient {
 
     private List<FFModelsFeatures.TargetSegment> getTargetSegments() {
         FFCache cache = this.config.cache;
-        List<FFModelsFeatures.TargetSegment> targetSegments = (List<FFModelsFeatures.TargetSegment>) cache.get(FFCacheKeys.getTargetSegmentsKey(cache));
+        List<FFModelsFeatures.TargetSegment> targetSegments = (List<FFModelsFeatures.TargetSegment>) cache.getSegments();
         if(targetSegments == null) {
             List<FFModelsFeatures.TargetSegment> updated = this.api.getTargetSegments(this.envAndClusterRequestParams());
-            cache.put(FFCacheKeys.getTargetSegmentsKey(cache), updated, this.config.featureConfigTimeToLive);
+            cache.putSegments(updated, this.config.featureConfigTimeToLive);
             return updated;
         }
         return targetSegments;

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -3,6 +3,18 @@ public class FFOrgCache implements FFCache {
     private String cacheNamespace = 'local';
     private String cachePartition = 'basic';
 
+    private enum EntryType { FEATURE, SEGMENT, AUTH }
+
+    /* Cache keys cannot have any non-alphanumeric characters */
+    private String stripNonAlphanumeric(String str) {
+        Pattern filter = Pattern.compile('[^a-zA-Z0-9]');
+        return filter.matcher(str).replaceAll('');
+    }
+
+    private String makeKey(EntryType type, String key) {
+        return cacheNamespace + '.' + cachePartition + '.' + type.name() + stripNonAlphanumeric(key);
+    }
+
     public FFOrgCache(String cacheNamespace, String cachePartition) {
         if(cacheNamespace != null) {
             if (cacheNamespace.equals('')) {
@@ -21,19 +33,58 @@ public class FFOrgCache implements FFCache {
         }
     }
 
-    public void put(String key, Object value, Integer ttl) {
-        Cache.Org.put(key, value, ttl);
+    public void putFeatures(List<FFModelsFeatures.FeatureConfig> features, Integer ttl) {
+        for (FFModelsFeatures.FeatureConfig feature: features) {
+            String key = makeKey(EntryType.FEATURE, feature.feature);
+            System.debug('Caching feature config: ' + key);
+            Cache.Org.put(key, feature, ttl);
+        }
     }
 
-    public Object get(String key) {
-        return Cache.Org.get(key);
+    public void putSegments(List<FFModelsFeatures.TargetSegment> segments, Integer ttl) {
+        for (FFModelsFeatures.TargetSegment segment: segments) {
+            String key = makeKey(EntryType.SEGMENT, segment.identifier);
+            System.debug('Caching segment config: ' + key);
+            Cache.Org.put(key, segment, ttl);
+        }
+    }
+
+    public void putAuth(String sdkKey, Map<String, String> authData, Integer ttl) {
+        String key = makeKey(EntryType.AUTH, sdkKey);
+        System.debug('Caching auth: ' + key);
+        Cache.Org.put(key, authData, ttl);
+    }
+
+    public List<FFModelsFeatures.FeatureConfig> getFeatures() {
+        List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
+        for (String nextKey : Cache.Org.getKeys()) {
+            if (nextKey.startsWith(EntryType.FEATURE.name())) {
+                System.debug('get feature key: ' + nextKey);
+                features.add((FFModelsFeatures.FeatureConfig)Cache.Org.get(nextKey));
+            }
+        }
+        return features;
+    }
+
+    public List<FFModelsFeatures.TargetSegment> getSegments() {
+        List<FFModelsFeatures.TargetSegment> segments = new List<FFModelsFeatures.TargetSegment>();
+        for (String nextKey : Cache.Org.getKeys()) {
+            if (nextKey.startsWith(EntryType.SEGMENT.name())) {
+                System.debug('get targetsegment key: ' + nextKey);
+                segments.add((FFModelsFeatures.TargetSegment)Cache.Org.get(nextKey));
+            }
+        }
+        return segments;
+    }
+
+    public Map<String, String> getAuth(String sdkKey) {
+        String key = makeKey(EntryType.AUTH, sdkKey);
+        System.debug('Get auth: ' + key);
+        return (Map<String, String>) Cache.Org.get(key);
     }
 
     public String getCacheNamespace() {
         return this.cacheNamespace;
     }
 
-    public String getCachePartition() {
-        return this.cachePartition;
-    }
 }

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -59,7 +59,6 @@ public class FFOrgCache implements FFCache {
         List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
         for (String nextKey : Cache.Org.getKeys()) {
             if (nextKey.startsWith(EntryType.FEATURE.name())) {
-                System.debug('get feature key: ' + nextKey);
                 features.add((FFModelsFeatures.FeatureConfig)Cache.Org.get(nextKey));
             }
         }
@@ -70,7 +69,6 @@ public class FFOrgCache implements FFCache {
         List<FFModelsFeatures.TargetSegment> segments = new List<FFModelsFeatures.TargetSegment>();
         for (String nextKey : Cache.Org.getKeys()) {
             if (nextKey.startsWith(EntryType.SEGMENT.name())) {
-                System.debug('get targetsegment key: ' + nextKey);
                 segments.add((FFModelsFeatures.TargetSegment)Cache.Org.get(nextKey));
             }
         }

--- a/force-app/test/FFAuthServiceCachedTest.cls
+++ b/force-app/test/FFAuthServiceCachedTest.cls
@@ -34,8 +34,8 @@ private class FFAuthServiceCachedTest {
        FFModels.AuthInfo result = authService.authenticate();
        System.assertEquals('2', result.cluster);
        System.assertEquals('test-env', result.environmentUUID);
-       String cacheKey = FFCacheKeys.getAuthCacheKey(config.cache, 'test-sdk-key');
-       Map<String, String> stored = (Map<String, String>)config.cache.get(cacheKey);
+       String cacheKey = FFCacheKeys.getAuthCacheKey('test-sdk-key');
+       Map<String, String> stored = (Map<String, String>)config.cache.getAuth(cacheKey);
        System.assertEquals(stored.get('environmentUUID'), 'test-env');
        System.assertEquals(stored.get('cluster'), '2');
        System.assertEquals(stored.get('jwt'), response.authToken);

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -41,12 +41,12 @@ private class FFClientTest {
         List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
         FFConfig config = FFConfig.builder().cache(new FFMockCache()).build();
         FFClient client = new FFClient(mockClientApi(features, targets), null, config, 'test', 'test');
-        System.assertEquals(null, config.cache.get(FFCacheKeys.getFeatureConfigsKey(config.cache)));
-        System.assertEquals(null, config.cache.get(FFCacheKeys.getTargetSegmentsKey(config.cache)));
+        System.assertEquals(null, config.cache.getFeatures());
+        System.assertEquals(null, config.cache.getSegments());
 
         client.updateCache();
-        System.assertEquals(0, ((List<FFModelsFeatures.FeatureConfig>)config.cache.get(FFCacheKeys.getFeatureConfigsKey(config.cache))).size());
-        System.assertEquals(0, ((List<FFModelsFeatures.TargetSegment>)config.cache.get(FFCacheKeys.getTargetSegmentsKey(config.cache))).size());
+        System.assertEquals(0, ((List<FFModelsFeatures.FeatureConfig>)config.cache.getFeatures()).size());
+        System.assertEquals(0, ((List<FFModelsFeatures.TargetSegment>)config.cache.getSegments()).size());
     }
 
     @isTest
@@ -60,8 +60,8 @@ private class FFClientTest {
         features.add(testFeature);
         
         FFCache cache = new FFMockCache();
-        cache.put(FFCacheKeys.getFeatureConfigsKey(cache), features, 1);
-        cache.put(FFCacheKeys.getTargetSegmentsKey(cache), targets, 1);
+        cache.putFeatures(features, 1);
+        cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).build();
 
         FFClient client = new FFClient(null, null, config, 'test', 'test');
@@ -89,8 +89,8 @@ private class FFClientTest {
         testFeature.defaultServe = new FFModelsFeatures.Serve();
         testFeature.defaultServe.variation = 'test';
         FFCache cache = new FFMockCache();
-        cache.put(FFCacheKeys.getFeatureConfigsKey(cache), features, 1);
-        cache.put(FFCacheKeys.getTargetSegmentsKey(cache), targets, 1);
+        cache.putFeatures(features, 1);
+        cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).evalExpireAfter(1).authExpireAfter(1).baseUrl('').eventsUrl('').featureConfigTimeToLive(1).build();
 
         FFClient client = new FFClient(null, null, config, 'test', 'test');
@@ -115,8 +115,8 @@ private class FFClientTest {
         testFeature.defaultServe = new FFModelsFeatures.Serve();
         testFeature.defaultServe.variation = 'test';
         FFCache cache = new FFMockCache();
-        cache.put(FFCacheKeys.getFeatureConfigsKey(cache), features, 1);
-        cache.put(FFCacheKeys.getTargetSegmentsKey(cache), targets, 1);
+        cache.putFeatures(features, 1);
+        cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).build();
 
         FFClient client = new FFClient(null, null, config, 'test', 'test');
@@ -197,8 +197,8 @@ private class FFClientTest {
         features.add(preFeature);
         
         FFCache cache = new FFMockCache();
-        cache.put(FFCacheKeys.getFeatureConfigsKey(cache), features, 1);
-        cache.put(FFCacheKeys.getTargetSegmentsKey(cache), targets, 1);
+        cache.putFeatures(features, 1);
+        cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).metricsEnabled().build();
 
         FFClient client = new FFClient(null, null, config, 'test', 'test');

--- a/force-app/test/FFMockCache.cls
+++ b/force-app/test/FFMockCache.cls
@@ -3,8 +3,30 @@ public class FFMockCache implements FFCache {
     public FFMockCache() {
         this.cache = new Map<String, Object>();
     }
-    public void put(String key, Object value, Integer ttl) { this.cache.put(key, value); }
-    public Object get(String key) { return this.cache.get(key);}
+
+    public void putFeatures(List<FFModelsFeatures.FeatureConfig> features, Integer ttl) {
+        this.cache.put('features', features);
+    }
+
+    public void putSegments(List<FFModelsFeatures.TargetSegment> segments, Integer ttl) {
+        this.cache.put('segments', segments);
+    }
+
+    public void putAuth(String key, Map<String, String> authData, Integer ttl) {
+        this.cache.put('auth'+key, authData);
+    }
+
+    public List<FFModelsFeatures.FeatureConfig> getFeatures() {
+        return (List<FFModelsFeatures.FeatureConfig>) this.cache.get('features');
+    }
+
+    public List<FFModelsFeatures.TargetSegment> getSegments() {
+        return (List<FFModelsFeatures.TargetSegment>) this.cache.get('segments');
+    }
+
+    public Map<String, String> getAuth(String key) {
+        return (Map<String, String>) this.cache.get('auth'+key);
+    }
+
     public String getCacheNamespace() { return 'TEST'; }
-    public String getCachePartition() { return 'TEST'; }
 }

--- a/force-app/test/FFOrgCacheTest.cls
+++ b/force-app/test/FFOrgCacheTest.cls
@@ -3,29 +3,17 @@ private class FFOrgCacheTest {
 
     @isTest
     private static void shouldSetDefaults() {
-        FFOrgCache orgCache = new FFOrgCache(null, null);
+        FFOrgCache orgCache = new FFOrgCache(null);
         System.assertEquals('local', orgCache.getCacheNamespace());
-        System.assertEquals('basic', orgCache.getCachePartition());
     }
 
     @isTest
     private static void shouldFailIfNamespaceIsEmpty() {
         try {
-            FFOrgCache orgCache = new FFOrgCache('', null);
+            FFOrgCache orgCache = new FFOrgCache('');
             System.assert(false, 'Should not get here');
         } catch(Exception e){
             System.assertEquals('cacheNamespace cannot be empty', e.getMessage());
         }
     }
-
-    @isTest
-    private static void shouldFailIfPartitionIsEmpty() {
-        try {
-            FFOrgCache orgCache = new FFOrgCache(null, '');
-            System.assert(false, 'Should not get here');
-        } catch(Exception e){
-            System.assertEquals('cachePartition cannot be empty', e.getMessage());
-        }
-    }
-
 }

--- a/force-app/test/FFOrgCacheTest.cls
+++ b/force-app/test/FFOrgCacheTest.cls
@@ -3,17 +3,27 @@ private class FFOrgCacheTest {
 
     @isTest
     private static void shouldSetDefaults() {
-        FFOrgCache orgCache = new FFOrgCache(null);
+        FFOrgCache orgCache = new FFOrgCache(null, null);
         System.assertEquals('local', orgCache.getCacheNamespace());
     }
 
     @isTest
     private static void shouldFailIfNamespaceIsEmpty() {
         try {
-            FFOrgCache orgCache = new FFOrgCache('');
+            FFOrgCache orgCache = new FFOrgCache('', null);
             System.assert(false, 'Should not get here');
         } catch(Exception e){
             System.assertEquals('cacheNamespace cannot be empty', e.getMessage());
+        }
+    }
+
+    @isTest
+    private static void shouldFailIfPartitionIsEmpty() {
+        try {
+            FFOrgCache orgCache = new FFOrgCache(null, '');
+            System.assert(false, 'Should not get here');
+        } catch(Exception e){
+            System.assertEquals('cachePartition cannot be empty', e.getMessage());
         }
     }
 }


### PR DESCRIPTION
[FFM-9071] - Rewrite flag/target segment cache

What
This is an update to the SDK's usage of the Platform Cache. Instead of loading all flag/segment data into 2 cache keys this change spreads the data across multiple keys.

Why
For customers with a lot of flags we're seeing Platform Cache limits of 100K being reached very quickly, which is causing an exception to be thrown and the SDK to fail in these cases.

Testing
Manual + unit

[FFM-9071]: https://harness.atlassian.net/browse/FFM-9071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ