### PR TITLE
FFM-10286 Add re-authentication mechanism + synchronous init option

### DIFF
--- a/force-app/main/classes/FFAuthService.cls
+++ b/force-app/main/classes/FFAuthService.cls
@@ -1,3 +1,5 @@
 public interface FFAuthService {
-    FFModels.AuthInfo authenticate();
+    FFModels.AuthInfo authenticate(Boolean force);
+    FFModels.LastAuthTime getLastAuthTime();
+    
 } 

--- a/force-app/main/classes/FFAuthService.cls
+++ b/force-app/main/classes/FFAuthService.cls
@@ -1,5 +1,5 @@
 public interface FFAuthService {
     FFModels.AuthInfo authenticate(Boolean force);
-    FFModels.LastAuthTime getLastAuthTime();
+    String getLastAuthTime();
     
 } 

--- a/force-app/main/classes/FFAuthService.cls
+++ b/force-app/main/classes/FFAuthService.cls
@@ -1,5 +1,4 @@
 public interface FFAuthService {
     FFModels.AuthInfo authenticate(Boolean force);
     String getLastAuthTime();
-    
 } 

--- a/force-app/main/classes/FFAuthService.cls
+++ b/force-app/main/classes/FFAuthService.cls
@@ -1,4 +1,4 @@
 public interface FFAuthService {
     FFModels.AuthInfo authenticate(Boolean force);
-    String getLastAuthTime();
+    Long getLastAuthTime();
 } 

--- a/force-app/main/classes/FFAuthService.cls
+++ b/force-app/main/classes/FFAuthService.cls
@@ -1,4 +1,5 @@
 public interface FFAuthService {
     FFModels.AuthInfo authenticate(Boolean force);
     Long getLastAuthTime();
+    Boolean isAuthTokenPresent();
 } 

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -27,9 +27,7 @@ public class FFAuthServiceCached implements FFAuthService {
 
     @TestVisible
     private void updateLastAuthTimeInCache(Long authTime) {
-        this.config.cache.putLastAuthTimeWithoutTTL(this.getLastAuthTimeKey(), new Map<String, String>{
-            FFClient.LAST_AUTH_TIME_KEY => String.valueOf(authTime)
-        });
+        this.config.cache.putLastAuthTimeWithoutTTL(this.getAuthCacheKey(), String.valueOf(authTime));
     }
 
     private FFModels.AuthInfo claimsFromCache() {
@@ -39,19 +37,12 @@ public class FFAuthServiceCached implements FFAuthService {
         return new FFModels.AuthInfo(authData.get(CACHE_KEY_JWT), authData.get(CACHE_KEY_ENVIRONMENT), authData.get(CACHE_KEY_CLUSTER));
     }
 
-    public FFModels.LastAuthTime getLastAuthTime() {
-        Map<String, String> lastAuthItem = (Map<String, String>)this.config.cache.getKey(this.getLastAuthTimeKey());
-        if(lastAuthItem == null) return null;
-        System.debug('Loading last authentication time from cache');
-        return new FFModels.LastAuthTime(lastAuthItem.get(FFClient.LAST_AUTH_TIME_KEY));
+    public String getLastAuthTime() {
+        return this.config.cache.getLastAuthKey(this.getAuthCacheKey());
     }
 
     private String getAuthCacheKey() {
         return FFCacheKeys.getCacheKey(this.sdkKey);
-    }
-
-    private String getLastAuthTimeKey() {
-        return FFCacheKeys.getCacheKey(this.sdkKey + FFClient.LAST_AUTH_TIME_KEY);
     }
 
     public FFModels.AuthInfo authenticate(Boolean force) {

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -8,6 +8,7 @@ public class FFAuthServiceCached implements FFAuthService {
     private final String CACHE_KEY_CLUSTER = 'cluster';
     private final String CACHE_KEY_JWT = 'jwt';
 
+
     public virtual class AuthException extends Exception {}
 
     public FFAuthServiceCached(String sdkKey, FFConfig config, FFAuthenticator authenticator) {
@@ -24,6 +25,12 @@ public class FFAuthServiceCached implements FFAuthService {
         }, this.config.authExpireAfter);
     }
 
+    private void updateLastAuthTimeInCache(FFModels.AuthInfo claims) {
+        this.config.cache.putLastAuthTimeWithoutTTL(this.getLastAuthTimeKey(), new Map<String, String>{
+            FFClient.LAST_AUTH_TIME_KEY => String.valueOf(Datetime.now().getTime())
+        });
+    }
+
     private FFModels.AuthInfo claimsFromCache() {
         Map<String, String> authData = (Map<String, String>)this.config.cache.getAuth(this.getAuthCacheKey());
         if(authData == null) return null;
@@ -31,11 +38,27 @@ public class FFAuthServiceCached implements FFAuthService {
         return new FFModels.AuthInfo(authData.get(CACHE_KEY_JWT), authData.get(CACHE_KEY_ENVIRONMENT), authData.get(CACHE_KEY_CLUSTER));
     }
 
+    public FFModels.LastAuthTime getLastAuthTime() {
+        Map<String, String> lastAuthItem = (Map<String, String>)this.config.cache.getAuth(this.getLastAuthTimeKey());
+        // TODO, don't return null, just indicate we should reauthenticate somehow
+        if(lastAuthItem == null) return null;
+        System.debug('Loading last authentication time from cache');
+        return new FFModels.LastAuthTime(lastAuthItem.get(FFClient.LAST_AUTH_TIME_KEY));
+    }
+
     private String getAuthCacheKey() {
         return FFCacheKeys.getAuthCacheKey(this.sdkKey);
     }
 
-    public FFModels.AuthInfo authenticate() {
+    private String getLastAuthTimeKey() {
+        return FFCacheKeys.getAuthCacheKey(this.sdkKey + FFClient.LAST_AUTH_TIME_KEY);
+    }
+
+    public FFModels.AuthInfo authenticate(Boolean force) {
+        if (force) {
+            System.debug('Force auth refresh requested, authenticating...');
+            return this.reauthenticate(0);
+        }
         FFModels.AuthInfo claims = this.claimsFromCache();
         if(claims != null) return claims;
         System.debug('Authentication token not found in cache, authenticating...');

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -36,6 +36,12 @@ public class FFAuthServiceCached implements FFAuthService {
         return new FFModels.AuthInfo(authData.get(CACHE_KEY_JWT), authData.get(CACHE_KEY_ENVIRONMENT), authData.get(CACHE_KEY_CLUSTER));
     }
 
+    public Boolean isAuthTokenPresent() {
+        Map<String, String> authData = (Map<String, String>)this.config.cache.getKey(this.getAuthCacheKey());
+        if(authData == null) return false;
+        return true;
+    }
+
     public Long getLastAuthTime() {
         return this.config.cache.getLastAuthKey(this.getAuthCacheKey());
     }

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -32,14 +32,14 @@ public class FFAuthServiceCached implements FFAuthService {
     }
 
     private FFModels.AuthInfo claimsFromCache() {
-        Map<String, String> authData = (Map<String, String>)this.config.cache.getAuth(this.getAuthCacheKey());
+        Map<String, String> authData = (Map<String, String>)this.config.cache.getKey(this.getAuthCacheKey());
         if(authData == null) return null;
         System.debug('Loading authentication data from cache');
         return new FFModels.AuthInfo(authData.get(CACHE_KEY_JWT), authData.get(CACHE_KEY_ENVIRONMENT), authData.get(CACHE_KEY_CLUSTER));
     }
 
     public FFModels.LastAuthTime getLastAuthTime() {
-        Map<String, String> lastAuthItem = (Map<String, String>)this.config.cache.getAuth(this.getLastAuthTimeKey());
+        Map<String, String> lastAuthItem = (Map<String, String>)this.config.cache.getKey(this.getLastAuthTimeKey());
         // TODO, don't return null, just indicate we should reauthenticate somehow
         if(lastAuthItem == null) return null;
         System.debug('Loading last authentication time from cache');
@@ -47,11 +47,11 @@ public class FFAuthServiceCached implements FFAuthService {
     }
 
     private String getAuthCacheKey() {
-        return FFCacheKeys.getAuthCacheKey(this.sdkKey);
+        return FFCacheKeys.getCacheKey(this.sdkKey);
     }
 
     private String getLastAuthTimeKey() {
-        return FFCacheKeys.getAuthCacheKey(this.sdkKey + FFClient.LAST_AUTH_TIME_KEY);
+        return FFCacheKeys.getCacheKey(this.sdkKey + FFClient.LAST_AUTH_TIME_KEY);
     }
 
     public FFModels.AuthInfo authenticate(Boolean force) {

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -82,8 +82,7 @@ public class FFAuthServiceCached implements FFAuthService {
         } catch (FFBase.ApiException e) {
             System.debug('Auth Error');
             System.debug(e);
-            // TODO retry on more than just 403
-            if(e.getStatusCode() == 403) {
+            if(e.getStatusCode() == 403 || e.getStatusCode() == 500) {
                 if(retry < this.config.authRetries) {
                     System.debug('Retrying authentication, retry no. ' + retry);
                     return this.reauthenticate(retry + 1);

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -25,9 +25,10 @@ public class FFAuthServiceCached implements FFAuthService {
         }, this.config.authExpireAfter);
     }
 
-    private void updateLastAuthTimeInCache(FFModels.AuthInfo claims) {
+    @TestVisible
+    private void updateLastAuthTimeInCache(Long authTime) {
         this.config.cache.putLastAuthTimeWithoutTTL(this.getLastAuthTimeKey(), new Map<String, String>{
-            FFClient.LAST_AUTH_TIME_KEY => String.valueOf(Datetime.now().getTime())
+            FFClient.LAST_AUTH_TIME_KEY => String.valueOf(authTime)
         });
     }
 
@@ -40,7 +41,6 @@ public class FFAuthServiceCached implements FFAuthService {
 
     public FFModels.LastAuthTime getLastAuthTime() {
         Map<String, String> lastAuthItem = (Map<String, String>)this.config.cache.getKey(this.getLastAuthTimeKey());
-        // TODO, don't return null, just indicate we should reauthenticate somehow
         if(lastAuthItem == null) return null;
         System.debug('Loading last authentication time from cache');
         return new FFModels.LastAuthTime(lastAuthItem.get(FFClient.LAST_AUTH_TIME_KEY));
@@ -83,8 +83,11 @@ public class FFAuthServiceCached implements FFAuthService {
             FFModels.JWTClaims claims = this.claimsFrom(result.authToken);
             FFModels.AuthInfo authClaims = new FFModels.AuthInfo(result.authToken, claims.environment, claims.clusterIdentifier);
             this.updateAuthInCache(authClaims);
+            Long authTime = Datetime.now().getTime();
+            this.updateLastAuthTimeInCache(authTime);
             System.debug('Env UUID ' + authClaims.environmentUUID);
             System.debug('Cluster ID ' + authClaims.cluster);
+            System.debug('Auth time ' + authTime);
             return authClaims;
         } catch (FFBase.ApiException e) {
             System.debug('Auth Error');

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -66,6 +66,7 @@ public class FFAuthServiceCached implements FFAuthService {
         } catch (FFBase.ApiException e) {
             System.debug('Auth Error');
             System.debug(e);
+            // TODO retry on more than just 403
             if(e.getStatusCode() == 403) {
                 if(retry < this.config.authRetries) {
                     System.debug('Retrying authentication, retry no. ' + retry);

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -8,7 +8,6 @@ public class FFAuthServiceCached implements FFAuthService {
     private final String CACHE_KEY_CLUSTER = 'cluster';
     private final String CACHE_KEY_JWT = 'jwt';
 
-
     public virtual class AuthException extends Exception {}
 
     public FFAuthServiceCached(String sdkKey, FFConfig config, FFAuthenticator authenticator) {

--- a/force-app/main/classes/FFAuthServiceCached.cls
+++ b/force-app/main/classes/FFAuthServiceCached.cls
@@ -26,7 +26,7 @@ public class FFAuthServiceCached implements FFAuthService {
 
     @TestVisible
     private void updateLastAuthTimeInCache(Long authTime) {
-        this.config.cache.putLastAuthTimeWithoutTTL(this.getAuthCacheKey(), String.valueOf(authTime));
+        this.config.cache.putLastAuthTimeWithoutTTL(this.getAuthCacheKey(), authTime);
     }
 
     private FFModels.AuthInfo claimsFromCache() {
@@ -36,7 +36,7 @@ public class FFAuthServiceCached implements FFAuthService {
         return new FFModels.AuthInfo(authData.get(CACHE_KEY_JWT), authData.get(CACHE_KEY_ENVIRONMENT), authData.get(CACHE_KEY_CLUSTER));
     }
 
-    public String getLastAuthTime() {
+    public Long getLastAuthTime() {
         return this.config.cache.getLastAuthKey(this.getAuthCacheKey());
     }
 

--- a/force-app/main/classes/FFCache.cls
+++ b/force-app/main/classes/FFCache.cls
@@ -3,6 +3,7 @@ public interface FFCache {
     void putFeatures(List<FFModelsFeatures.FeatureConfig> features, Integer ttl);
     void putSegments(List<FFModelsFeatures.TargetSegment> segments, Integer ttl);
     void putAuth(String key, Map<String, String> authData, Integer ttl);
+    void putLastAuthTimeWithoutTTL(String key, Map<String, String> lastAuthTime);
 
     List<FFModelsFeatures.FeatureConfig> getFeatures();
     List<FFModelsFeatures.TargetSegment> getSegments();

--- a/force-app/main/classes/FFCache.cls
+++ b/force-app/main/classes/FFCache.cls
@@ -7,7 +7,7 @@ public interface FFCache {
 
     List<FFModelsFeatures.FeatureConfig> getFeatures();
     List<FFModelsFeatures.TargetSegment> getSegments();
-    Map<String, String> getAuth(String key);
+    Map<String, String> getKey(String key);
 
     String getCacheNamespace();
 }

--- a/force-app/main/classes/FFCache.cls
+++ b/force-app/main/classes/FFCache.cls
@@ -3,11 +3,13 @@ public interface FFCache {
     void putFeatures(List<FFModelsFeatures.FeatureConfig> features, Integer ttl);
     void putSegments(List<FFModelsFeatures.TargetSegment> segments, Integer ttl);
     void putAuth(String key, Map<String, String> authData, Integer ttl);
-    void putLastAuthTimeWithoutTTL(String key, Map<String, String> lastAuthTime);
+    void putLastAuthTimeWithoutTTL(String key, String lastAuthTime);
 
     List<FFModelsFeatures.FeatureConfig> getFeatures();
     List<FFModelsFeatures.TargetSegment> getSegments();
     Map<String, String> getKey(String key);
+    String getLastAuthKey(String key);
+
 
     String getCacheNamespace();
 }

--- a/force-app/main/classes/FFCache.cls
+++ b/force-app/main/classes/FFCache.cls
@@ -3,12 +3,12 @@ public interface FFCache {
     void putFeatures(List<FFModelsFeatures.FeatureConfig> features, Integer ttl);
     void putSegments(List<FFModelsFeatures.TargetSegment> segments, Integer ttl);
     void putAuth(String key, Map<String, String> authData, Integer ttl);
-    void putLastAuthTimeWithoutTTL(String key, String lastAuthTime);
+    void putLastAuthTimeWithoutTTL(String key, Long lastAuthTime);
 
     List<FFModelsFeatures.FeatureConfig> getFeatures();
     List<FFModelsFeatures.TargetSegment> getSegments();
     Map<String, String> getKey(String key);
-    String getLastAuthKey(String key);
+    Long getLastAuthKey(String key);
 
     String getCacheNamespace();
 }

--- a/force-app/main/classes/FFCache.cls
+++ b/force-app/main/classes/FFCache.cls
@@ -10,6 +10,5 @@ public interface FFCache {
     Map<String, String> getKey(String key);
     String getLastAuthKey(String key);
 
-
     String getCacheNamespace();
 }

--- a/force-app/main/classes/FFCacheKeys.cls
+++ b/force-app/main/classes/FFCacheKeys.cls
@@ -1,7 +1,7 @@
 public abstract class FFCacheKeys {
 
-    public static String getAuthCacheKey(String sdkKey) {
-        return sdkKey.replaceAll('-', '');
+    public static String getCacheKey(String key) {
+        return key.replaceAll('-', '');
     }
 }
 

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -230,9 +230,11 @@ public class FFClient {
             // we manually trigger a reauthentication process. This ensures that a valid token is always available,
             // especially for jobs that run longer than the token's expiration period.
             FFModels.LastAuthTime lastAuthData = this.client.authService.getLastAuthTime();
+           
             // This should be set when the SDK authenticates, so this is a defesnive check to
             // force a re-auth if it can't be found, perhaps due to a cache eviction.
             if(lastAuthData == null) {
+                System.debug('Unable to find last authentication time in cache, forcing authentication');
                 FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
                 this.client.api.getClient().setJWTToken(authResult.authToken);
                 this.client.metricsApi.getClient().setJWTToken(authResult.authToken);
@@ -240,7 +242,6 @@ public class FFClient {
                 return true;
             }
 
-        
             Long lastAuthTimeMillis = Long.valueOf(lastAuthData.lastAuthTimeMillis);
             Datetime lastAuthTime = Datetime.newInstance(lastAuthTimeMillis);
             

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -215,14 +215,17 @@ public class FFClient {
 
         private final FFClient client;
 
-        // Flags/segements are fetched at initialization to populate the cache for any evaluations
-        // that are made immediately or shortly after. This flag ensures
-        // we don't immediately re-poll after the initial fetch, instead waiting
-        // for the next scheduled poll interval.
-        private Boolean initialFetchAccountedFor = false;
-    
-        public CacheUpdator(FFClient client) {
+        // If withWaitForInitialized is requested Flags/segements are fetched at initialization
+        // to populate the cache so that evaluations are up to date immediately.
+        // This flag ensures we don't immediately re-poll in this case.
+        // Default the flag to true, as we only want to skip the first poll if waitForInitialized is requeted.
+        private Boolean initialFetchAccountedFor = true;
+
+        public CacheUpdator(FFClient client, Boolean waitForInitialized) {
             this.client = client;
+            if (waitForInitialized) {
+                this.initialFetchAccountedFor = false;
+            }
         }
 
         public Object call(String action, Map<String, Object> args) {
@@ -247,7 +250,7 @@ public class FFClient {
                 System.debug('Unable to find authentication token in cache, forcing authentication...');
                 return this.authAndUpdateCache();
             }
-           
+
             // This should be set when the SDK authenticates, so this is a defesnive check to
             // force a re-auth if it can't be found, perhaps due to a cache eviction.
             if(lastAuthTimeMillis == null) {
@@ -257,7 +260,7 @@ public class FFClient {
             }
 
             Datetime lastAuthTime = Datetime.newInstance(lastAuthTimeMillis);
-            
+
             // Calculate the expiration time based on last authentication time and the expiration interval
             Datetime expirationTime = lastAuthTime.addSeconds(this.client.config.authExpireAfter);
 

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -258,7 +258,7 @@ public class FFClient {
 
             // Subtract one hour (3600 seconds) from the expiration time to add a margin
             Datetime marginTime = expirationTime.addSeconds(-3600);
-
+            
             if (Datetime.now().getTime() < marginTime.getTime()) {
                 System.debug('Authentication token has not expired');
                 this.client.updateCache();

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -206,4 +206,37 @@ public class FFClient {
     public static FFClientBuilder builder(String sdkKey, FFConfig config){
         return new FFClientBuilder(sdkKey, config);
     }
+
+    public class CacheUpdator implements Callable {
+
+        private final FFClient client;
+
+        // The JWT token used for authentication is set to expire after 24 hours. In scenarios involving long-running
+        // jobs, it's possible that the token stored in the Platform Cache might not get refreshed if no authentication
+        // calls are made within this 24-hour period. To handle such cases and prevent authentication failures,
+        // we manually trigger a reauthentication process. This ensures that a valid token is always available,
+        // especially for jobs that run longer than the token's expiration period.
+        private static final Long REAUTH_INTERVAL_SECONDS = 23 * 60 * 60; 
+        private static Datetime lastAuthTime = Datetime.now();
+    
+
+        public CacheUpdator(FFClient client) {
+            this.client = client;
+        }
+
+        public Object call(String action, Map<String, Object> args) {
+            // Check if 23 hours have passed since the last reauthentication
+            if (Datetime.now().getTime() - lastAuthTime.getTime() > REAUTH_INTERVAL_SECONDS * 1000) {
+                reauthenticate(); 
+                lastAuthTime = Datetime.now();
+            }
+            
+            this.client.updateCache();
+            return true;
+        }
+
+        private void reauthenticate() {
+            
+        }
+    }
 }

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -227,20 +227,19 @@ public class FFClient {
             // calls are made within this 24-hour period. To handle such cases and prevent authentication failures,
             // we manually trigger a reauthentication process. This ensures that a valid token is always available,
             // especially for jobs that run longer than the token's expiration period.
-            String lastAuthData = this.client.authService.getLastAuthTime();
+            Long lastAuthTimeMillis = this.client.authService.getLastAuthTime();
            
             // This should be set when the SDK authenticates, so this is a defesnive check to
             // force a re-auth if it can't be found, perhaps due to a cache eviction.
-            if(lastAuthData == null) {
+            if(lastAuthTimeMillis == null) {
                 System.debug('Unable to find last authentication time in cache, forcing authentication');
                 FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
                 this.client.api.getClient().setJWTToken(authResult.authToken);
                 this.client.metricsApi.getClient().setJWTToken(authResult.authToken);
-                 this.client.updateCache();
+                this.client.updateCache();
                 return true;
             }
 
-            Long lastAuthTimeMillis = Long.valueOf(lastAuthData);
             Datetime lastAuthTime = Datetime.newInstance(lastAuthTimeMillis);
             
             // Calculate the expiration time based on last authentication time and the expiration interval

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -257,6 +257,7 @@ public class FFClient {
                 this.client.metricsApi.getClient().setJWTToken(authResult.authToken);            
             }
 
+            System.debug('Authentication token has not expired');
             // Update the features/segments cache
             this.client.updateCache();
             return true;

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -3,6 +3,7 @@ public class FFClient {
     private final FFConfig config;
     private final FFClientApi api;
     private final FFMetricsApi metricsApi;
+    private final FFAuthService authService;
 
     private String environmentUUID;
     private String cluster = '1';
@@ -10,11 +11,16 @@ public class FFClient {
     private static Integer maxRetry = 5;
     private final Long waitInterval = 2000;
 
+
+
+    public static String LAST_AUTH_TIME_KEY = 'lastAuthTime';
+
     public virtual class AuthException extends Exception {}
 
-    public FFClient(FFClientApi api, FFMetricsApi metricsApi, FFConfig config, String environmentUUID, String cluster) {
+    public FFClient(FFAuthService authService, FFClientApi api, FFMetricsApi metricsApi, FFConfig config, String environmentUUID, String cluster) {
         this.config = config;
         this.api = api;
+        this.authService = authService;
         this.metricsApi = metricsApi;
         this.environmentUUID = environmentUUID;
         this.cluster = cluster;
@@ -30,10 +36,10 @@ public class FFClient {
         FFClientApi api = new FFClientApi(apiClient);
         FFMetricsApi metricsApi = new FFMetricsApi(eventsClient);
         FFAuthService authService = new FFAuthServiceCached(sdkKey, config, api);
-        FFModels.AuthInfo authResult = authService.authenticate();
+        FFModels.AuthInfo authResult = authService.authenticate(false);
         apiClient.setJWTToken(authResult.authToken);
         eventsClient.setJWTToken(authResult.authToken);
-        return new FFClient(api, metricsApi, config, authResult.environmentUUID, authResult.cluster);
+        return new FFClient(authService, api, metricsApi, config, authResult.environmentUUID, authResult.cluster);
     }
 
     public void updateCache() {
@@ -210,33 +216,48 @@ public class FFClient {
     public class CacheUpdator implements Callable {
 
         private final FFClient client;
-
-        // The JWT token used for authentication is set to expire after 24 hours. In scenarios involving long-running
-        // jobs, it's possible that the token stored in the Platform Cache might not get refreshed if no authentication
-        // calls are made within this 24-hour period. To handle such cases and prevent authentication failures,
-        // we manually trigger a reauthentication process. This ensures that a valid token is always available,
-        // especially for jobs that run longer than the token's expiration period.
-        private static final Long REAUTH_INTERVAL_SECONDS = 23 * 60 * 60; 
-        private static Datetime lastAuthTime = Datetime.now();
     
-
         public CacheUpdator(FFClient client) {
             this.client = client;
         }
 
+     
         public Object call(String action, Map<String, Object> args) {
-            // Check if 23 hours have passed since the last reauthentication
-            if (Datetime.now().getTime() - lastAuthTime.getTime() > REAUTH_INTERVAL_SECONDS * 1000) {
-                reauthenticate(); 
-                lastAuthTime = Datetime.now();
+            // Polling reauthentication mechanism:
+            // The JWT token used for authentication is set to expire after 24 hours. In scenarios involving long-running
+            // jobs, it's possible that the token stored in the Platform Cache might not get refreshed if no authentication
+            // calls are made within this 24-hour period. To handle such cases and prevent authentication failures,
+            // we manually trigger a reauthentication process. This ensures that a valid token is always available,
+            // especially for jobs that run longer than the token's expiration period.
+            FFModels.LastAuthTime lastAuthData = this.client.authService.getLastAuthTime();
+            // This should be set when the SDK authenticates, so this is a defesnive check to
+            // force a re-auth if it can't be found, perhaps due to a cache eviction.
+            if(lastAuthData == null) {
+                FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
+                this.client.api.getClient().setJWTToken(authResult.authToken);
+                this.client.metricsApi.getClient().setJWTToken(authResult.authToken);
+                 this.client.updateCache();
+                return true;
             }
+
+        
+            Long lastAuthTimeMillis = Long.valueOf(lastAuthData.lastAuthTimeMillis);
+            Datetime lastAuthTime = Datetime.newInstance(lastAuthTimeMillis);
             
+            // Calculate the expiration time based on last authentication time and the expiration interval
+            Datetime expirationTime = lastAuthTime.addSeconds(this.client.config.authExpireAfter);
+
+            // Check if the current time is after the calculated expiration time
+            if (Datetime.now().getTime() > expirationTime.getTime()) {
+                FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
+                this.client.api.getClient().setJWTToken(authResult.authToken);
+                this.client.metricsApi.getClient().setJWTToken(authResult.authToken);            
+            }
+
+            // Update the features/segments cache
             this.client.updateCache();
             return true;
         }
-
-        private void reauthenticate() {
-            
-        }
+        
     }
 }

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -214,13 +214,24 @@ public class FFClient {
     public class CacheUpdator implements Callable {
 
         private final FFClient client;
+
+        // Flags/segements are fetched at initialization to populate the cache for any evaluations
+        // that are made immediately or shortly after. This flag ensures
+        // we don't immediately re-poll after the initial fetch, instead waiting
+        // for the next scheduled poll interval.
+        private Boolean initialFetchAccountedFor = false;
     
         public CacheUpdator(FFClient client) {
             this.client = client;
         }
 
-     
         public Object call(String action, Map<String, Object> args) {
+
+            if (!initialFetchAccountedFor) {
+                this.initialFetchAccountedFor = true;
+                return true;
+            }
+
             // Polling reauthentication mechanism:
             // The JWT token used for authentication is set to expire after 24 hours. In scenarios involving long-running
             // jobs, it's possible that the token stored in the Platform Cache might not get refreshed if no authentication

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -247,8 +247,13 @@ public class FFClient {
             // Calculate the expiration time based on last authentication time and the expiration interval
             Datetime expirationTime = lastAuthTime.addSeconds(this.client.config.authExpireAfter);
 
+            // Subtract one hour (3600 seconds) from the expiration time to add a margin
+            Datetime marginTime = expirationTime.addSeconds(-3600);
+
+
             // Check if the current time is after the calculated expiration time
-            if (Datetime.now().getTime() > expirationTime.getTime()) {
+            if (Datetime.now().getTime() > marginTime.getTime()) {
+                System.debug('Authentication token has expired, re-authenticating...');
                 FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
                 this.client.api.getClient().setJWTToken(authResult.authToken);
                 this.client.metricsApi.getClient().setJWTToken(authResult.authToken);            

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -11,8 +11,6 @@ public class FFClient {
     private static Integer maxRetry = 5;
     private final Long waitInterval = 2000;
 
-
-
     public static String LAST_AUTH_TIME_KEY = 'lastAuthTime';
 
     public virtual class AuthException extends Exception {}
@@ -229,7 +227,7 @@ public class FFClient {
             // calls are made within this 24-hour period. To handle such cases and prevent authentication failures,
             // we manually trigger a reauthentication process. This ensures that a valid token is always available,
             // especially for jobs that run longer than the token's expiration period.
-            FFModels.LastAuthTime lastAuthData = this.client.authService.getLastAuthTime();
+            String lastAuthData = this.client.authService.getLastAuthTime();
            
             // This should be set when the SDK authenticates, so this is a defesnive check to
             // force a re-auth if it can't be found, perhaps due to a cache eviction.
@@ -242,7 +240,7 @@ public class FFClient {
                 return true;
             }
 
-            Long lastAuthTimeMillis = Long.valueOf(lastAuthData.lastAuthTimeMillis);
+            Long lastAuthTimeMillis = Long.valueOf(lastAuthData);
             Datetime lastAuthTime = Datetime.newInstance(lastAuthTimeMillis);
             
             // Calculate the expiration time based on last authentication time and the expiration interval

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -239,16 +239,21 @@ public class FFClient {
             // we manually trigger a reauthentication process. This ensures that a valid token is always available,
             // especially for jobs that run longer than the token's expiration period.
             Long lastAuthTimeMillis = this.client.authService.getLastAuthTime();
+
+            Boolean isAuthTokenPresent = this.client.authService.isAuthTokenPresent();
+
+            // Defensive check to force a re-auth if the auth token is not in the cache
+            if (!isAuthTokenPresent) {
+                System.debug('Unable to find authentication token in cache, forcing authentication...');
+                return this.authAndUpdateCache();
+            }
            
             // This should be set when the SDK authenticates, so this is a defesnive check to
             // force a re-auth if it can't be found, perhaps due to a cache eviction.
             if(lastAuthTimeMillis == null) {
                 System.debug('Unable to find last authentication time in cache, forcing authentication');
-                FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
-                this.client.api.getClient().setJWTToken(authResult.authToken);
-                this.client.metricsApi.getClient().setJWTToken(authResult.authToken);
-                this.client.updateCache();
-                return true;
+                return this.authAndUpdateCache();
+
             }
 
             Datetime lastAuthTime = Datetime.newInstance(lastAuthTimeMillis);
@@ -258,7 +263,7 @@ public class FFClient {
 
             // Subtract one hour (3600 seconds) from the expiration time to add a margin
             Datetime marginTime = expirationTime.addSeconds(-3600);
-            
+
             if (Datetime.now().getTime() < marginTime.getTime()) {
                 System.debug('Authentication token has not expired');
                 this.client.updateCache();
@@ -267,11 +272,15 @@ public class FFClient {
 
             // Auth token has expired, so re-authenticate before updating cache
             System.debug('Authentication token has expired, re-authenticating...');
+            return this.authAndUpdateCache();
+        }
+
+        private Boolean authAndUpdateCache() {
             FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
             this.client.api.getClient().setJWTToken(authResult.authToken);
-            this.client.metricsApi.getClient().setJWTToken(authResult.authToken);     
+            this.client.metricsApi.getClient().setJWTToken(authResult.authToken);
             this.client.updateCache();
-            return true;          
+            return true;
         }
     }
 }

--- a/force-app/main/classes/FFClient.cls
+++ b/force-app/main/classes/FFClient.cls
@@ -248,20 +248,19 @@ public class FFClient {
             // Subtract one hour (3600 seconds) from the expiration time to add a margin
             Datetime marginTime = expirationTime.addSeconds(-3600);
 
-
-            // Check if the current time is after the calculated expiration time
-            if (Datetime.now().getTime() > marginTime.getTime()) {
-                System.debug('Authentication token has expired, re-authenticating...');
-                FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
-                this.client.api.getClient().setJWTToken(authResult.authToken);
-                this.client.metricsApi.getClient().setJWTToken(authResult.authToken);            
+            if (Datetime.now().getTime() < marginTime.getTime()) {
+                System.debug('Authentication token has not expired');
+                this.client.updateCache();
+                return true;
             }
 
-            System.debug('Authentication token has not expired');
-            // Update the features/segments cache
+            // Auth token has expired, so re-authenticate before updating cache
+            System.debug('Authentication token has expired, re-authenticating...');
+            FFModels.AuthInfo authResult = this.client.authService.authenticate(true);
+            this.client.api.getClient().setJWTToken(authResult.authToken);
+            this.client.metricsApi.getClient().setJWTToken(authResult.authToken);     
             this.client.updateCache();
-            return true;
+            return true;          
         }
-        
     }
 }

--- a/force-app/main/classes/FFClientBuilder.cls
+++ b/force-app/main/classes/FFClientBuilder.cls
@@ -23,13 +23,19 @@ public class FFClientBuilder {
     }
 
     public FFClient build(){
+        Boolean isPollingEnabled = pollingIntervalInSeconds > 0;
         FFClient client = FFClient.create(this.sdkKey, this.config);
-        if(pollingIntervalInSeconds > 0) {
-            new FFPoller(new FFClient.CacheUpdator(client))
-            .staticDelay(this.pollingIntervalInSeconds)
-            .untilTrue(new AlwaysFalse())
-            .execute();
+        // If polling isn't enabled, fetch flags/segments here as the poller is responsible for
+        // updating the cache when it's enabled.
+        if (!isPollingEnabled) {
+            client.updateCache();
+            return client;
         }
+
+        new FFPoller(new FFClient.CacheUpdator(client))
+        .staticDelay(this.pollingIntervalInSeconds)
+        .untilTrue(new AlwaysFalse())
+        .execute();
         return client;
     }
 }

--- a/force-app/main/classes/FFClientBuilder.cls
+++ b/force-app/main/classes/FFClientBuilder.cls
@@ -4,6 +4,7 @@ public class FFClientBuilder {
     private final FFConfig config;
     private Integer pollingIntervalInSeconds = 0;
 
+    @TestVisible
     private class AlwaysFalse implements Callable {
 
         public Object call(String action, Map<String, Object> args) {

--- a/force-app/main/classes/FFClientBuilder.cls
+++ b/force-app/main/classes/FFClientBuilder.cls
@@ -23,12 +23,13 @@ public class FFClientBuilder {
     }
 
     public FFClient build(){
-        Boolean isPollingEnabled = pollingIntervalInSeconds > 0;
         FFClient client = FFClient.create(this.sdkKey, this.config);
-        // If polling isn't enabled, fetch flags/segments here as the poller is responsible for
-        // updating the cache when it's enabled.
+
+        // Fetch initial cache values 
+        client.updateCache();
+
+        Boolean isPollingEnabled = pollingIntervalInSeconds > 0;
         if (!isPollingEnabled) {
-            client.updateCache();
             return client;
         }
 

--- a/force-app/main/classes/FFClientBuilder.cls
+++ b/force-app/main/classes/FFClientBuilder.cls
@@ -3,6 +3,8 @@ public class FFClientBuilder {
     private final String sdkKey;
     private final FFConfig config;
     private Integer pollingIntervalInSeconds = 0;
+    private Boolean waitForinitialized = false;
+
 
     @TestVisible
     private class AlwaysFalse implements Callable {
@@ -22,18 +24,26 @@ public class FFClientBuilder {
        return this;
     }
 
+    public FFClientBuilder withWaitForInitialized(Boolean waitForInitialzed) {
+        this.waitForinitialized = waitForInitialzed;
+        return this;
+     }
+
     public FFClient build(){
         FFClient client = FFClient.create(this.sdkKey, this.config);
 
-        // Fetch initial cache values 
-        client.updateCache();
+        
+        if (this.waitForinitialized) {
+            // Fetch flags/segments before returning the client
+            client.updateCache();
+        }
 
         Boolean isPollingEnabled = pollingIntervalInSeconds > 0;
         if (!isPollingEnabled) {
             return client;
         }
 
-        new FFPoller(new FFClient.CacheUpdator(client))
+        new FFPoller(new FFClient.CacheUpdator(client, waitForinitialized))
         .staticDelay(this.pollingIntervalInSeconds)
         .untilTrue(new AlwaysFalse())
         .execute();

--- a/force-app/main/classes/FFClientBuilder.cls
+++ b/force-app/main/classes/FFClientBuilder.cls
@@ -4,20 +4,6 @@ public class FFClientBuilder {
     private final FFConfig config;
     private Integer pollingIntervalInSeconds = 0;
 
-    private class CacheUpdator implements Callable {
-
-        private final FFClient client;
-
-        public CacheUpdator(FFClient client) {
-            this.client = client;
-        }
-
-        public Object call(String action, Map<String, Object> args) {
-            this.client.updateCache();
-            return true;
-        }
-    }
-
     private class AlwaysFalse implements Callable {
 
         public Object call(String action, Map<String, Object> args) {
@@ -38,7 +24,7 @@ public class FFClientBuilder {
     public FFClient build(){
         FFClient client = FFClient.create(this.sdkKey, this.config);
         if(pollingIntervalInSeconds > 0) {
-            new FFPoller(new CacheUpdator(client))
+            new FFPoller(new FFClient.CacheUpdator(client))
             .staticDelay(this.pollingIntervalInSeconds)
             .untilTrue(new AlwaysFalse())
             .execute();

--- a/force-app/main/classes/FFConfig.cls
+++ b/force-app/main/classes/FFConfig.cls
@@ -71,13 +71,13 @@ public class FFConfig {
             return this;
         }
 
-        public Builder evalExpireAfter(Integer ms) {
-            this.evalExpireAfter = ms;
+        public Builder evalExpireAfter(Integer seconds) {
+            this.evalExpireAfter = seconds;
             return this;
         }
 
-        public Builder authExpireAfter(Integer ms) {
-            this.authExpireAfter = ms;
+        public Builder authExpireAfter(Integer seconds) {
+            this.authExpireAfter = seconds;
             return this;
         }
 

--- a/force-app/main/classes/FFModels.cls
+++ b/force-app/main/classes/FFModels.cls
@@ -25,4 +25,11 @@ public abstract class FFModels {
         public String clusterIdentifier {get;set;}
     }
 
+    public class LastAuthTime {
+        public String lastAuthTimeMillis {get;set;}
+        public LastAuthTime(String lastAuthTimeMillis) {
+            this.lastAuthTimeMillis = lastAuthTimeMillis;
+        }
+    }
+
 }

--- a/force-app/main/classes/FFModels.cls
+++ b/force-app/main/classes/FFModels.cls
@@ -25,11 +25,4 @@ public abstract class FFModels {
         public String clusterIdentifier {get;set;}
     }
 
-    public class LastAuthTime {
-        public String lastAuthTimeMillis {get;set;}
-        public LastAuthTime(String lastAuthTimeMillis) {
-            this.lastAuthTimeMillis = lastAuthTimeMillis;
-        }
-    }
-
 }

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -55,7 +55,7 @@ public class FFOrgCache implements FFCache {
         Cache.Org.put(key, authData, ttl);
     }
 
-    public void putLastAuthTimeWithoutTTL(String sdkKey, String lastAuthTime) {
+    public void putLastAuthTimeWithoutTTL(String sdkKey, Long lastAuthTime) {
         String key = makeKey(EntryType.AUTHTIME, sdkKey);
         System.debug('Caching last auth time: ' + key);
         Cache.Org.put(key, lastAuthTime);
@@ -87,10 +87,10 @@ public class FFOrgCache implements FFCache {
         return (Map<String, String>) Cache.Org.get(key);
     }
 
-    public String getLastAuthKey(String sdkKey) {
+    public Long getLastAuthKey(String sdkKey) {
         String key = makeKey(EntryType.AUTHTIME, sdkKey);
         System.debug('Get last auth: ' + key);
-        return (String) Cache.Org.get(key);
+        return (Long) Cache.Org.get(key);
     }
 
     public String getCacheNamespace() {

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -3,7 +3,7 @@ public class FFOrgCache implements FFCache {
     private String cacheNamespace = 'local';
     private String cachePartition = 'basic';
 
-    private enum EntryType { FEATURE, SEGMENT, AUTH, LAST_AUTH }
+    private enum EntryType { FEATURE, SEGMENT, AUTH, LASTAUTH }
 
     /* Cache keys cannot have any non-alphanumeric characters */
     private String stripNonAlphanumeric(String str) {
@@ -56,7 +56,7 @@ public class FFOrgCache implements FFCache {
     }
 
     public void putLastAuthTimeWithoutTTL(String sdkKey, String lastAuthTime) {
-        String key = makeKey(EntryType.LAST_AUTH, sdkKey);
+        String key = makeKey(EntryType.LASTAUTH, sdkKey);
         System.debug('Caching last auth time: ' + key);
         Cache.Org.put(key, lastAuthTime);
     }
@@ -88,7 +88,7 @@ public class FFOrgCache implements FFCache {
     }
 
     public String getLastAuthKey(String sdkKey) {
-        String key = makeKey(EntryType.LAST_AUTH, sdkKey);
+        String key = makeKey(EntryType.LASTAUTH, sdkKey);
         System.debug('Get last auth: ' + key);
         return (String) Cache.Org.get(key);
     }

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -3,7 +3,7 @@ public class FFOrgCache implements FFCache {
     private String cacheNamespace = 'local';
     private String cachePartition = 'basic';
 
-    private enum EntryType { FEATURE, SEGMENT, AUTH, LASTAUTH }
+    private enum EntryType { FEATURE, SEGMENT, AUTH, AUTHTIME }
 
     /* Cache keys cannot have any non-alphanumeric characters */
     private String stripNonAlphanumeric(String str) {
@@ -56,7 +56,7 @@ public class FFOrgCache implements FFCache {
     }
 
     public void putLastAuthTimeWithoutTTL(String sdkKey, String lastAuthTime) {
-        String key = makeKey(EntryType.LASTAUTH, sdkKey);
+        String key = makeKey(EntryType.AUTHTIME, sdkKey);
         System.debug('Caching last auth time: ' + key);
         Cache.Org.put(key, lastAuthTime);
     }
@@ -88,7 +88,7 @@ public class FFOrgCache implements FFCache {
     }
 
     public String getLastAuthKey(String sdkKey) {
-        String key = makeKey(EntryType.LASTAUTH, sdkKey);
+        String key = makeKey(EntryType.AUTHTIME, sdkKey);
         System.debug('Get last auth: ' + key);
         return (String) Cache.Org.get(key);
     }

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -3,7 +3,7 @@ public class FFOrgCache implements FFCache {
     private String cacheNamespace = 'local';
     private String cachePartition = 'basic';
 
-    private enum EntryType { FEATURE, SEGMENT, AUTH }
+    private enum EntryType { FEATURE, SEGMENT, AUTH, LAST_AUTH }
 
     /* Cache keys cannot have any non-alphanumeric characters */
     private String stripNonAlphanumeric(String str) {
@@ -55,6 +55,12 @@ public class FFOrgCache implements FFCache {
         Cache.Org.put(key, authData, ttl);
     }
 
+    public void putLastAuthTimeWithoutTTL(String sdkKey, Map<String, String> lastAuthTime) {
+        String key = makeKey(EntryType.LAST_AUTH, sdkKey + FFClient.LAST_AUTH_TIME_KEY);
+        System.debug('Caching last auth time: ' + key);
+        Cache.Org.put(key, lastAuthTime);
+    }
+
     public List<FFModelsFeatures.FeatureConfig> getFeatures() {
         List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
         for (String nextKey : Cache.Org.getKeys()) {
@@ -75,7 +81,7 @@ public class FFOrgCache implements FFCache {
         return segments;
     }
 
-    public Map<String, String> getAuth(String sdkKey) {
+    public Map<String, String> getKey(String sdkKey) {
         String key = makeKey(EntryType.AUTH, sdkKey);
         System.debug('Get auth: ' + key);
         return (Map<String, String>) Cache.Org.get(key);

--- a/force-app/main/classes/FFOrgCache.cls
+++ b/force-app/main/classes/FFOrgCache.cls
@@ -55,8 +55,8 @@ public class FFOrgCache implements FFCache {
         Cache.Org.put(key, authData, ttl);
     }
 
-    public void putLastAuthTimeWithoutTTL(String sdkKey, Map<String, String> lastAuthTime) {
-        String key = makeKey(EntryType.LAST_AUTH, sdkKey + FFClient.LAST_AUTH_TIME_KEY);
+    public void putLastAuthTimeWithoutTTL(String sdkKey, String lastAuthTime) {
+        String key = makeKey(EntryType.LAST_AUTH, sdkKey);
         System.debug('Caching last auth time: ' + key);
         Cache.Org.put(key, lastAuthTime);
     }
@@ -85,6 +85,12 @@ public class FFOrgCache implements FFCache {
         String key = makeKey(EntryType.AUTH, sdkKey);
         System.debug('Get auth: ' + key);
         return (Map<String, String>) Cache.Org.get(key);
+    }
+
+    public String getLastAuthKey(String sdkKey) {
+        String key = makeKey(EntryType.LAST_AUTH, sdkKey);
+        System.debug('Get last auth: ' + key);
+        return (String) Cache.Org.get(key);
     }
 
     public String getCacheNamespace() {

--- a/force-app/test/FFAuthServiceCachedTest.cls
+++ b/force-app/test/FFAuthServiceCachedTest.cls
@@ -31,15 +31,20 @@ private class FFAuthServiceCachedTest {
        response.authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnZpcm9ubWVudCI6InRlc3QtZW52IiwiY2x1c3RlcklkZW50aWZpZXIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.J806LOlfV15bTVzQVNfKil8VGQOVadXcXpfqTJ_xrZM';
        MockAuthenticator authenticator = new MockAuthenticator(response);
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
-       FFModels.AuthInfo result = authService.authenticate();
+       FFModels.AuthInfo result = authService.authenticate(false);
        System.assertEquals('2', result.cluster);
        System.assertEquals('test-env', result.environmentUUID);
-       String cacheKey = FFCacheKeys.getAuthCacheKey('test-sdk-key');
-       Map<String, String> stored = (Map<String, String>)config.cache.getAuth(cacheKey);
+       String authCacheKey = FFCacheKeys.getCacheKey('test-sdk-key');
+       Map<String, String> stored = (Map<String, String>)config.cache.getKey(authCacheKey);
        System.assertEquals(stored.get('environmentUUID'), 'test-env');
        System.assertEquals(stored.get('cluster'), '2');
        System.assertEquals(stored.get('jwt'), response.authToken);
+
+       // Ensure lastAuthTime gets cached
+       String lastAuthKey = FFCacheKeys.getCacheKey('test-sdk-key'+FFClient.LAST_AUTH_TIME_KEY);
     }
+
+
 
     @isTest
     private static void shouldRetryAuthenticationOn403() {
@@ -48,7 +53,7 @@ private class FFAuthServiceCachedTest {
        response.authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnZpcm9ubWVudCI6InRlc3QtZW52IiwiY2x1c3RlcklkZW50aWZpZXIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.J806LOlfV15bTVzQVNfKil8VGQOVadXcXpfqTJ_xrZM';
        MockAuthenticator authenticator = new MockAuthenticator(response, 2); // FAIL TWICE
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
-       FFModels.AuthInfo result = authService.authenticate();
+       FFModels.AuthInfo result = authService.authenticate(false);
        System.assertEquals('2', result.cluster);
        System.assertEquals('test-env', result.environmentUUID);
        System.assertEquals(3, authenticator.called); // CALLED THREE TIMES
@@ -62,7 +67,7 @@ private class FFAuthServiceCachedTest {
        MockAuthenticator authenticator = new MockAuthenticator(response, 20); // FAIL More than max times
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
        try {
-        FFModels.AuthInfo result = authService.authenticate();
+        FFModels.AuthInfo result = authService.authenticate(false);
             System.assert(false, 'Shouldn\'t get here');
        } catch(Exception e) {
             System.assertEquals(11, authenticator.called); // CALLED 1 Initial time + 10 Retries
@@ -77,7 +82,7 @@ private class FFAuthServiceCachedTest {
        MockAuthenticator authenticator = new MockAuthenticator(response, 20); // FAIL More than max times
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
        try {
-        FFModels.AuthInfo result = authService.authenticate();
+        FFModels.AuthInfo result = authService.authenticate(false);
             System.assert(false, 'Shouldn\'t get here');
        } catch(Exception e) {
             System.assertEquals(5, authenticator.called); // CALLED 1 Initial time + 10 Retries

--- a/force-app/test/FFAuthServiceCachedTest.cls
+++ b/force-app/test/FFAuthServiceCachedTest.cls
@@ -35,13 +35,16 @@ private class FFAuthServiceCachedTest {
        System.assertEquals('2', result.cluster);
        System.assertEquals('test-env', result.environmentUUID);
        String authCacheKey = FFCacheKeys.getCacheKey('test-sdk-key');
-       Map<String, String> stored = (Map<String, String>)config.cache.getKey(authCacheKey);
+       Map<String, String> stored = (Map<String, String>)config.cache.getKey('auth'+authCacheKey);
        System.assertEquals(stored.get('environmentUUID'), 'test-env');
        System.assertEquals(stored.get('cluster'), '2');
        System.assertEquals(stored.get('jwt'), response.authToken);
 
        // Ensure lastAuthTime gets cached
        String lastAuthKey = FFCacheKeys.getCacheKey('test-sdk-key'+FFClient.LAST_AUTH_TIME_KEY);
+       Map<String, String> storedLastAuth = (Map<String, String>)config.cache.getKey('lastAuth'+lastAuthKey);
+       // Just assert that the key is there. We can't verify the timestamp in the test.
+       System.assertNotEquals(storedLastAuth.get(FFClient.LAST_AUTH_TIME_KEY), null);
     }
 
 

--- a/force-app/test/FFAuthServiceCachedTest.cls
+++ b/force-app/test/FFAuthServiceCachedTest.cls
@@ -41,10 +41,10 @@ private class FFAuthServiceCachedTest {
        System.assertEquals(stored.get('jwt'), response.authToken);
 
        // Ensure lastAuthTime gets cached
-       String lastAuthKey = FFCacheKeys.getCacheKey('test-sdk-key'+FFClient.LAST_AUTH_TIME_KEY);
-       Map<String, String> storedLastAuth = (Map<String, String>)config.cache.getKey('lastAuth'+lastAuthKey);
+       String lastAuthKey = FFCacheKeys.getCacheKey('test-sdk-key');
+       String lastAuth = config.cache.getLastAuthKey('lastAuth'+lastAuthKey);
        // Just assert that the key is there. We can't verify the timestamp in the test.
-       System.assertNotEquals(storedLastAuth.get(FFClient.LAST_AUTH_TIME_KEY), null);
+       System.assertNotEquals(lastAuth, null);
     }
 
 

--- a/force-app/test/FFAuthServiceCachedTest.cls
+++ b/force-app/test/FFAuthServiceCachedTest.cls
@@ -44,7 +44,7 @@ private class FFAuthServiceCachedTest {
 
        // Ensure lastAuthTime gets cached
        String lastAuthKey = FFCacheKeys.getCacheKey('test-sdk-key');
-       String lastAuth = config.cache.getLastAuthKey('lastAuth'+lastAuthKey);
+       Long lastAuth = config.cache.getLastAuthKey('lastAuth'+lastAuthKey);
        // Just assert that the key is there. We can't verify the timestamp in the test.
        System.assertNotEquals(lastAuth, null);
     }

--- a/force-app/test/FFAuthServiceCachedTest.cls
+++ b/force-app/test/FFAuthServiceCachedTest.cls
@@ -5,20 +5,22 @@ private class FFAuthServiceCachedTest {
         public Integer called { get; set; }
         public Integer throwTimes { get; set; }
         public FFModels.AuthenticationResponse response {get;set;}
+        public Integer errorCode;
         public MockAuthenticator(FFModels.AuthenticationResponse response) {
             this.response = response;
             this.called = 0;
             this.throwTimes = 0;
         }
-        public MockAuthenticator(FFModels.AuthenticationResponse successResponse, Integer throwTimes) {
+        public MockAuthenticator(FFModels.AuthenticationResponse successResponse, Integer throwTimes, Integer errorCode) {
             this.called = 0;
             this.response = successResponse;
             this.throwTimes = throwTimes;
+            this.errorCode = errorCode;
         }
         public FFModels.AuthenticationResponse authenticate(Map<String, Object> params) {
             this.called++;
             if(this.called <= this.throwTimes) {
-                throw new FFBase.ApiException(403, 'Forbidden', new Map<String,String>(), '');
+                throw new FFBase.ApiException(this.errorCode, 'Forbidden', new Map<String,String>(), '');
             }
             return this.response;
         }
@@ -54,7 +56,21 @@ private class FFAuthServiceCachedTest {
        FFConfig config = FFConfig.builder().cache(new FFMockCache()).build();
        FFModels.AuthenticationResponse response = new FFModels.AuthenticationResponse();
        response.authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnZpcm9ubWVudCI6InRlc3QtZW52IiwiY2x1c3RlcklkZW50aWZpZXIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.J806LOlfV15bTVzQVNfKil8VGQOVadXcXpfqTJ_xrZM';
-       MockAuthenticator authenticator = new MockAuthenticator(response, 2); // FAIL TWICE
+       MockAuthenticator authenticator = new MockAuthenticator(response, 2, 403); // FAIL TWICE
+       FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
+       FFModels.AuthInfo result = authService.authenticate(false);
+       System.assertEquals('2', result.cluster);
+       System.assertEquals('test-env', result.environmentUUID);
+       System.assertEquals(3, authenticator.called); // CALLED THREE TIMES
+    }
+
+
+    @isTest
+    private static void shouldRetryAuthenticationOn500() {
+       FFConfig config = FFConfig.builder().cache(new FFMockCache()).build();
+       FFModels.AuthenticationResponse response = new FFModels.AuthenticationResponse();
+       response.authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnZpcm9ubWVudCI6InRlc3QtZW52IiwiY2x1c3RlcklkZW50aWZpZXIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.J806LOlfV15bTVzQVNfKil8VGQOVadXcXpfqTJ_xrZM';
+       MockAuthenticator authenticator = new MockAuthenticator(response, 2, 500); // FAIL TWICE
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
        FFModels.AuthInfo result = authService.authenticate(false);
        System.assertEquals('2', result.cluster);
@@ -67,7 +83,7 @@ private class FFAuthServiceCachedTest {
        FFConfig config = FFConfig.builder().cache(new FFMockCache()).build();
        FFModels.AuthenticationResponse response = new FFModels.AuthenticationResponse();
        response.authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnZpcm9ubWVudCI6InRlc3QtZW52IiwiY2x1c3RlcklkZW50aWZpZXIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.J806LOlfV15bTVzQVNfKil8VGQOVadXcXpfqTJ_xrZM';
-       MockAuthenticator authenticator = new MockAuthenticator(response, 20); // FAIL More than max times
+       MockAuthenticator authenticator = new MockAuthenticator(response, 20, 500); // FAIL More than max times
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
        try {
         FFModels.AuthInfo result = authService.authenticate(false);
@@ -82,7 +98,7 @@ private class FFAuthServiceCachedTest {
        FFConfig config = FFConfig.builder().cache(new FFMockCache()).authRetries(4).build();
        FFModels.AuthenticationResponse response = new FFModels.AuthenticationResponse();
        response.authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbnZpcm9ubWVudCI6InRlc3QtZW52IiwiY2x1c3RlcklkZW50aWZpZXIiOiIyIiwiaWF0IjoxNTE2MjM5MDIyfQ.J806LOlfV15bTVzQVNfKil8VGQOVadXcXpfqTJ_xrZM';
-       MockAuthenticator authenticator = new MockAuthenticator(response, 20); // FAIL More than max times
+       MockAuthenticator authenticator = new MockAuthenticator(response, 20, 500); // FAIL More than max times
        FFAuthServiceCached authService = new FFAuthServiceCached('test-sdk-key', config, authenticator);
        try {
         FFModels.AuthInfo result = authService.authenticate(false);

--- a/force-app/test/FFClientApiTest.cls
+++ b/force-app/test/FFClientApiTest.cls
@@ -25,6 +25,39 @@ private class FFClientApiTest {
     }
 
     @isTest
+    private static void authenticateUnauthorizedTest() {
+        // Create a mock response for 401 Unauthorized
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setBody('Unauthorized access');
+        res.setStatusCode(401);
+        res.setStatus('Unauthorized');
+
+        Test.setMock(HttpCalloutMock.class, new FFResponseMock(res));
+
+        // Prepare the request and client
+        FFModels.AuthenticationRequest req = new FFModels.AuthenticationRequest();
+        Map<String, Object> params = new Map<String, Object>{
+            'ffAuthenticationRequest' => req
+        };
+
+        FFBaseCallout client = new FFBaseCallout('test', 'test');
+        FFClientApi api = new FFClientApi(client);
+
+        // Perform the test and handle the expected exception
+        Boolean caughtException = false;
+        try {
+            api.authenticate(params);
+        } catch (FFBase.ApiException e) {
+            caughtException = true;
+            System.assertEquals(401, e.getStatusCode());
+            System.assertEquals('API returned HTTP 401: Unauthorized', e.getMessage());
+        }
+
+        System.assert(caughtException, 'Expected an ApiException for unauthorized access');
+    }
+
+    @isTest
     private static void getFeatureConfigsTest() {
         List<FFModelsFeatures.FeatureConfig> mockResponse = new List<FFModelsFeatures.FeatureConfig>();
         FFModelsFeatures.FeatureConfig feature = new FFModelsFeatures.FeatureConfig();
@@ -50,6 +83,42 @@ private class FFClientApiTest {
         FFClientApi api = new FFClientApi(client);
         String actualResponse = JSON.serialize(api.getFeatureConfigs(params));
         System.assertEquals(serielized, actualResponse);
+    }
+
+    @isTest
+    private static void getFeatureConfigsUnauthorizedTest() {
+        // Create a mock response for 401 Unauthorized
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setBody('Unauthorized access');
+        res.setStatusCode(401);
+        res.setStatus('Unauthorized');
+
+        Test.setMock(HttpCalloutMock.class, new FFResponseMock(res));
+
+        // Prepare the request and client
+        FFModels.AuthenticationRequest req = new FFModels.AuthenticationRequest();
+        // Map<String, Object> params = new Map<String, Object>{
+        //     'ffAuthenticationRequest' => req
+        // };
+        Map<String, Object> params = new Map<String, Object>{
+            'environmentUUID' => 'test',
+            'cluster' => 'test'
+        };
+        FFBaseCallout client = new FFBaseCallout('test', 'test');
+        FFClientApi api = new FFClientApi(client);
+
+        // Perform the test and handle the expected exception
+        Boolean caughtException = false;
+        try {
+            api.getFeatureConfigs(params);
+        } catch (FFBase.ApiException e) {
+            caughtException = true;
+            System.assertEquals(401, e.getStatusCode());
+            System.assertEquals('API returned HTTP 401: Unauthorized', e.getMessage());
+        }
+
+        System.assert(caughtException, 'Expected an ApiException for unauthorized access');
     }
 
     @isTest
@@ -86,4 +155,37 @@ private class FFClientApiTest {
         String actualResponse = JSON.serialize(api.getTargetSegments(params));
         System.assertEquals(serielized, actualResponse);
     }
+
+
+    @isTest
+    private static void getTargetSegmentsUnauthorizedTest() {
+        // Create a mock response for 401 Unauthorized
+        HttpResponse res = new HttpResponse();
+        res.setHeader('Content-Type', 'application/json');
+        res.setBody('Unauthorized access');
+        res.setStatusCode(401);
+        res.setStatus('Unauthorized');
+
+        Test.setMock(HttpCalloutMock.class, new FFResponseMock(res));
+
+        // Prepare the request and client
+        FFModels.AuthenticationRequest req = new FFModels.AuthenticationRequest();
+        Map<String, Object> params = new Map<String, Object>{
+            'environmentUUID' => 'test',
+            'cluster' => 'test'
+        };
+        FFBaseCallout client = new FFBaseCallout('test', 'test');
+        FFClientApi api = new FFClientApi(client);
+
+        // Perform the test and handle the expected exception
+        Boolean caughtException = false;
+        try {
+            api.getTargetSegments(params);
+        } catch (FFBase.ApiException e) {
+            caughtException = true;
+            System.assertEquals(401, e.getStatusCode());
+            System.assertEquals('API returned HTTP 401: Unauthorized', e.getMessage());
+        }
+    }
+
 }

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -24,6 +24,7 @@ private class FFClientTest {
         private FFModels.AuthInfo mockAuthInfo;
         private Long mockLastAuthTime;
         public Boolean authenticateCalled = false;
+        public Boolean lastAuthTimeCalled = false;
         public Boolean simulateEvictedAuthToken = false;
     
         public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
@@ -41,6 +42,7 @@ private class FFClientTest {
         }
     
         public Long getLastAuthTime() {
+            this.lastAuthTimeCalled = true;
             return mockLastAuthTime;
         }
 
@@ -285,9 +287,6 @@ private class FFClientTest {
         // Instantiate the CacheUpdator with the FFClient instance
         FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
-        // Directly invoke the logic that would be triggered by the poller
-        // Call the cacheUpdator twice, because it skips on the first iteration.
-        cacheUpdator.call(null, null);
         cacheUpdator.call(null, null);
 
         // Verify that reauthentication was triggered due to the token being near expiration
@@ -316,9 +315,6 @@ private class FFClientTest {
         // Instantiate the CacheUpdator with the FFClient instance
         FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
-        // Directly invoke the logic that would be triggered by the poller
-        // Call the cacheUpdator twice, because it skips on the first iteration.
-        cacheUpdator.call(null, null);
         cacheUpdator.call(null, null);
 
         // Verify that reauthentication was triggered due to the token missing
@@ -346,9 +342,6 @@ private class FFClientTest {
         // Instantiate the CacheUpdator with the FFClient instance
         FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
-        // Directly invoke the logic that would be triggered by the poller
-        // Call the cacheUpdator twice, because it skips on the first iteration.
-        cacheUpdator.call(null, null);
         cacheUpdator.call(null, null);
 
         // Verify that reauthentication was triggered due to the token missing
@@ -380,6 +373,34 @@ private class FFClientTest {
 
         // Assert that authentication hasn't happened 
         System.assertEquals(false, mockAuthService.authenticateCalled, 'Reauthentication was incorrectly triggered');
+    }
+
+    @isTest
+    private static void shouldSkipFirstPollIfWaitForInitialized() {
+        // Create mock authentication information
+        FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+        MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
+
+        // Set the last authentication time to be very recent
+        Long recentTimeMillis = Datetime.now().addSeconds(-100).getTime();
+        mockAuthService.setLastAuthTime(recentTimeMillis);
+
+        // Create the FFClient configuration with a specified expiration interval
+        FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
+                                    .cache(new FFMockCache()).build();
+
+        List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
+        List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+        FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
+
+        // set waitForInitialized to true
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, true);
+
+        // Do the initial poll
+        cacheUpdator.call(null, null);
+    
+        // Assert that the cache updator doesn't check lastAuthTime on first call
+        System.assertEquals(false, mockAuthService.lastAuthTimeCalled, 'Initial poll wasn not skipped when waitForInitialized was requested');
     }
 
 }

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -22,7 +22,7 @@ private class FFClientTest {
 
     private class MockFFAuthService implements FFAuthService {
         private FFModels.AuthInfo mockAuthInfo;
-        private String mockLastAuthTime;
+        private Long mockLastAuthTime;
         public Boolean authenticateCalled = false;
     
         public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
@@ -34,11 +34,11 @@ private class FFClientTest {
             return mockAuthInfo;
         }
     
-        public String getLastAuthTime() {
+        public Long getLastAuthTime() {
             return mockLastAuthTime;
         }
     
-        public void setLastAuthTime(String lastAuthTime) {
+        public void setLastAuthTime(Long lastAuthTime) {
             this.mockLastAuthTime = lastAuthTime;
         }
     }
@@ -256,7 +256,7 @@ private class FFClientTest {
         // Set the last authentication time to be just over 23 hours ago
         // This simulates the condition where the token is near its expiration
         Long pastTimeMillis = Datetime.now().addSeconds(-((23 * 60 * 60) + 1)).getTime();
-        mockAuthService.setLastAuthTime(String.valueOf(pastTimeMillis));
+        mockAuthService.setLastAuthTime(pastTimeMillis);
 
         // Create the FFClient configuration with a specified expiration interval
         FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
@@ -288,7 +288,7 @@ private class FFClientTest {
 
         // Set the last authentication time to be very recent
         Long recentTimeMillis = Datetime.now().addSeconds(-100).getTime();
-        mockAuthService.setLastAuthTime(String.valueOf(recentTimeMillis));
+        mockAuthService.setLastAuthTime(recentTimeMillis);
 
         // Create the FFClient configuration with a specified expiration interval
         FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -22,7 +22,7 @@ private class FFClientTest {
 
     private class MockFFAuthService implements FFAuthService {
         private FFModels.AuthInfo mockAuthInfo;
-        private FFModels.LastAuthTime mockLastAuthTime;
+        private String mockLastAuthTime;
         public Boolean authenticateCalled = false;
     
         public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
@@ -34,11 +34,11 @@ private class FFClientTest {
             return mockAuthInfo;
         }
     
-        public FFModels.LastAuthTime getLastAuthTime() {
+        public String getLastAuthTime() {
             return mockLastAuthTime;
         }
     
-        public void setLastAuthTime(FFModels.LastAuthTime lastAuthTime) {
+        public void setLastAuthTime(String lastAuthTime) {
             this.mockLastAuthTime = lastAuthTime;
         }
     }
@@ -279,7 +279,7 @@ private class FFClientTest {
         // Set the last authentication time to be just over 23 hours ago
         // This simulates the condition where the token is near its expiration
         Long pastTimeMillis = Datetime.now().addSeconds(-((23 * 60 * 60) + 1)).getTime();
-        mockAuthService.setLastAuthTime(new FFModels.LastAuthTime(String.valueOf(pastTimeMillis)));
+        mockAuthService.setLastAuthTime(String.valueOf(pastTimeMillis));
 
         // Create the FFClient configuration with a specified expiration interval
         FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
@@ -311,7 +311,7 @@ private class FFClientTest {
 
         // Set the last authentication time to be very recent
         Long recentTimeMillis = Datetime.now().addSeconds(-100).getTime();
-        mockAuthService.setLastAuthTime(new FFModels.LastAuthTime(String.valueOf(recentTimeMillis)));
+        mockAuthService.setLastAuthTime(String.valueOf(recentTimeMillis));
 
         // Create the FFClient configuration with a specified expiration interval
         FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -16,7 +16,7 @@ private class FFClientTest {
             if (endpoint.contains('/client/env/{environmentUUID}/feature-configs')) {
                 return httpResponse(features);
             } else return httpResponse(targets);
-            
+
         }
     }
 
@@ -303,5 +303,33 @@ private class FFClientTest {
         System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
     }
 
+    @isTest
+    private static void shouldNotReauthenticateWhenTokenIsStillValid() {
+        // Create mock authentication information
+        FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+        MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
+
+        // Set the last authentication time to be very recent
+        Long recentTimeMillis = Datetime.now().addSeconds(-100).getTime();
+        mockAuthService.setLastAuthTime(new FFModels.LastAuthTime(String.valueOf(recentTimeMillis)));
+
+        // Create the FFClient configuration with a specified expiration interval
+        FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
+                                    .cache(new FFMockCache()).build();
+
+
+
+        List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
+        List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+        FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
+
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+
+
+        cacheUpdator.call(null, null);
+
+        // Assert that authentication hasn't happened 
+        System.assertEquals(false, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
+    }
 
 }

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -17,6 +17,25 @@ private class FFClientTest {
         }
     }
 
+    private class MockFFAuthService implements FFAuthService {
+        private FFModels.AuthInfo mockAuthInfo;
+        private FFModels.LastAuthTime mockLastAuthTime;
+
+    
+        public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
+            this.mockAuthInfo = mockAuthInfo;
+        }
+    
+        public FFModels.AuthInfo authenticate(Boolean force) {
+            return mockAuthInfo;
+        }
+
+        public FFModels.LastAuthTime getLastAuthTime() {
+            return mockLastAuthTime;
+        }
+    
+    }
+
     private static HttpResponse httpResponse(Object content) {
         HttpResponse res = new HttpResponse();
         res.setHeader('Content-Type', 'application/json');
@@ -37,10 +56,15 @@ private class FFClientTest {
 
     @isTest
     private static void shouldUpdateCacheWithLatestFromHttpCalls() {
+        FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+        MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
+        
         List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
         List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+
+
         FFConfig config = FFConfig.builder().cache(new FFMockCache()).build();
-        FFClient client = new FFClient(mockClientApi(features, targets), null, config, 'test', 'test');
+        FFClient client = new FFClient(null, mockClientApi(features, targets), null, config, 'test', 'test');
         System.assertEquals(null, config.cache.getFeatures());
         System.assertEquals(null, config.cache.getSegments());
 
@@ -64,7 +88,7 @@ private class FFClientTest {
         cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).build();
 
-        FFClient client = new FFClient(null, null, config, 'test', 'test');
+        FFClient client = new FFClient(null, null, null, config, 'test', 'test');
         FFTarget target = FFTarget.builder().identifier('test').build();
         System.assertEquals(false, client.boolVariation('test-feature', target, false));
         System.assertEquals(new Map<String, Object>(), client.jsonVariation('test-feature', target, new Map<String, Object>(), Map<String, Object>.class));
@@ -93,7 +117,7 @@ private class FFClientTest {
         cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).evalExpireAfter(1).authExpireAfter(1).baseUrl('').eventsUrl('').featureConfigTimeToLive(1).build();
 
-        FFClient client = new FFClient(null, null, config, 'test', 'test');
+        FFClient client = new FFClient(null, null, null, config, 'test', 'test');
         FFTarget target = new FFTarget('test', '');
         target.attributes = new Map<String, Object> { 'a' => 'b' };
         System.assertEquals(true, client.boolVariation('test-feature', target, false));
@@ -119,7 +143,7 @@ private class FFClientTest {
         cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).build();
 
-        FFClient client = new FFClient(null, null, config, 'test', 'test');
+        FFClient client = new FFClient(null, null, null, config, 'test', 'test');
         FFTarget target = new FFTarget('test', '');
         target.attributes = new Map<String, Object> { 'a' => 'b' };
         switch on kind {
@@ -201,7 +225,7 @@ private class FFClientTest {
         cache.putSegments(targets, 1);
         FFConfig config = FFConfig.builder().cache(cache).metricsEnabled().build();
 
-        FFClient client = new FFClient(null, null, config, 'test', 'test');
+        FFClient client = new FFClient(null, null, null, config, 'test', 'test');
         FFTarget target = FFTarget.builder().identifier('test').anonymous(false).attributes(null).build();
         System.assertEquals(false, client.boolVariation('test-feature', target, true));
     }

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -306,7 +306,7 @@ private class FFClientTest {
         cacheUpdator.call(null, null);
 
         // Assert that authentication hasn't happened 
-        System.assertEquals(false, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
+        System.assertEquals(false, mockAuthService.authenticateCalled, 'Reauthentication was incorrectly triggered');
     }
 
 }

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -11,30 +11,38 @@ private class FFClientTest {
         }
     
         public HttpResponse respond(HttpRequest request) {
-            if(request.getEndpoint() == '/client/env/{environmentUUID}/feature-configs') {
+            String endpoint = request.getEndpoint();
+    
+            if (endpoint.contains('/client/env/{environmentUUID}/feature-configs')) {
                 return httpResponse(features);
             } else return httpResponse(targets);
+            
         }
     }
 
     private class MockFFAuthService implements FFAuthService {
         private FFModels.AuthInfo mockAuthInfo;
         private FFModels.LastAuthTime mockLastAuthTime;
-
+        public Boolean authenticateCalled = false;
     
         public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
             this.mockAuthInfo = mockAuthInfo;
         }
     
         public FFModels.AuthInfo authenticate(Boolean force) {
+            authenticateCalled = true;
             return mockAuthInfo;
         }
-
+    
         public FFModels.LastAuthTime getLastAuthTime() {
             return mockLastAuthTime;
         }
     
+        public void setLastAuthTime(FFModels.LastAuthTime lastAuthTime) {
+            this.mockLastAuthTime = lastAuthTime;
+        }
     }
+    
 
     private static HttpResponse httpResponse(Object content) {
         HttpResponse res = new HttpResponse();
@@ -45,13 +53,22 @@ private class FFClientTest {
         return res;
     }
 
-    private static FFClientApi mockClientApi(List<FFModelsFeatures.FeatureConfig> features, List<FFModelsFeatures.TargetSegment> targets) {
+    private static FFClientApi mockApi(List<FFModelsFeatures.FeatureConfig> features, List<FFModelsFeatures.TargetSegment> targets) {
         Test.setMock(HttpCalloutMock.class, new Responder(features, targets));
         Map<String, Object> params = new Map<String, Object>{
             'environmentUUID' => 'test',
             'cluster' => 'test'
         };
         return new FFClientApi(new FFBaseCallout('test', 'test'));
+    }
+
+    private static FFMetricsApi mockMetricsApi(List<FFModelsFeatures.FeatureConfig> features, List<FFModelsFeatures.TargetSegment> targets) {
+        Test.setMock(HttpCalloutMock.class, new Responder(features, targets));
+        Map<String, Object> params = new Map<String, Object>{
+            'environmentUUID' => 'test',
+            'cluster' => 'test'
+        };
+        return new FFMetricsApi(new FFBaseCallout('test', 'test'));
     }
 
     @isTest
@@ -64,7 +81,7 @@ private class FFClientTest {
 
 
         FFConfig config = FFConfig.builder().cache(new FFMockCache()).build();
-        FFClient client = new FFClient(null, mockClientApi(features, targets), null, config, 'test', 'test');
+        FFClient client = new FFClient(null, mockApi(features, targets), null, config, 'test', 'test');
         System.assertEquals(null, config.cache.getFeatures());
         System.assertEquals(null, config.cache.getSegments());
 
@@ -229,4 +246,62 @@ private class FFClientTest {
         FFTarget target = FFTarget.builder().identifier('test').anonymous(false).attributes(null).build();
         System.assertEquals(false, client.boolVariation('test-feature', target, true));
     }
+
+    // @isTest
+    // private static void shouldReauthenticateWhenTokenIsAboutToExpire() {
+    //     FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+    //     MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
+
+    //     // Set the last authentication time to be just over 23 hours ago
+    //     Long pastTimeMillis = Datetime.now().addSeconds(-((23 * 60 * 60) + 1)).getTime();
+    //     mockAuthService.setLastAuthTime(new FFModels.LastAuthTime(String.valueOf(pastTimeMillis)));
+
+    //     FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60).cache(new FFMockCache()).build();
+    //     FFClient client = new FFClient(mockAuthService, null, null, config, 'test', 'test');
+
+    //     new FFPoller(new FFClient.CacheUpdator(client))
+    //     .staticDelay(1)
+    //     .untilTrue(new FFClientBuilder.AlwaysFalse())
+    //     .execute();
+    
+
+
+    //     // Verify that reauthentication was triggered
+    //     System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
+    // }
+
+    @isTest
+    private static void shouldReauthenticateWhenTokenIsAboutToExpire() {
+        // Create mock authentication information
+        FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+        MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
+
+        // Set the last authentication time to be just over 23 hours ago
+        // This simulates the condition where the token is near its expiration
+        Long pastTimeMillis = Datetime.now().addSeconds(-((23 * 60 * 60) + 1)).getTime();
+        mockAuthService.setLastAuthTime(new FFModels.LastAuthTime(String.valueOf(pastTimeMillis)));
+
+        // Create the FFClient configuration with a specified expiration interval
+        FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
+                                    .cache(new FFMockCache()).build();
+
+
+
+        List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
+        List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+        // Instantiate FFClient with the mock auth service
+        FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
+
+        // Instantiate the CacheUpdator with the FFClient instance
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+
+        // Directly invoke the logic that would be triggered by the poller
+        // This should check the last authentication time and decide whether to reauthenticate
+        cacheUpdator.call(null, null);
+
+        // Verify that reauthentication was triggered due to the token being near expiration
+        System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
+    }
+
+
 }

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -283,7 +283,7 @@ private class FFClientTest {
         FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
 
         // Instantiate the CacheUpdator with the FFClient instance
-        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
         // Directly invoke the logic that would be triggered by the poller
         // Call the cacheUpdator twice, because it skips on the first iteration.
@@ -314,7 +314,7 @@ private class FFClientTest {
         FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
 
         // Instantiate the CacheUpdator with the FFClient instance
-        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
         // Directly invoke the logic that would be triggered by the poller
         // Call the cacheUpdator twice, because it skips on the first iteration.
@@ -344,7 +344,7 @@ private class FFClientTest {
         FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
 
         // Instantiate the CacheUpdator with the FFClient instance
-        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
         // Directly invoke the logic that would be triggered by the poller
         // Call the cacheUpdator twice, because it skips on the first iteration.
@@ -375,7 +375,7 @@ private class FFClientTest {
         List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
         FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
 
-        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client, false);
 
 
         cacheUpdator.call(null, null);

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -24,9 +24,15 @@ private class FFClientTest {
         private FFModels.AuthInfo mockAuthInfo;
         private Long mockLastAuthTime;
         public Boolean authenticateCalled = false;
+        public Boolean simulateEvictedAuthToken;
     
         public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
             this.mockAuthInfo = mockAuthInfo;
+        }
+
+        public MockFFAuthService(FFModels.AuthInfo mockAuthInfo, Boolean simulateEvictedAuthToken) {
+            this.mockAuthInfo = mockAuthInfo;
+            this.simulateEvictedAuthToken = simulateEvictedAuthToken;
         }
     
         public FFModels.AuthInfo authenticate(Boolean force) {
@@ -39,6 +45,9 @@ private class FFClientTest {
         }
 
         public Boolean isAuthTokenPresent() {
+            if (this.simulateEvictedAuthToken) {
+                return false;
+            }
             return true;
         }
     
@@ -282,6 +291,37 @@ private class FFClientTest {
         cacheUpdator.call(null, null);
 
         // Verify that reauthentication was triggered due to the token being near expiration
+        System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
+    }
+
+    @isTest
+    private static void shouldReauthenticateWhenTokenIsMissing() {
+        // Create mock authentication information
+        FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+        MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo, true);
+
+        // Set the last authentication time to now
+        Long pastTimeMillis = Datetime.now().getTime();
+        mockAuthService.setLastAuthTime(pastTimeMillis);
+
+        // Create the FFClient configuration with a specified expiration interval
+        FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
+                                    .cache(new FFMockCache()).build();
+
+        List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
+        List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+        // Instantiate FFClient with the mock auth service
+        FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
+
+        // Instantiate the CacheUpdator with the FFClient instance
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+
+        // Directly invoke the logic that would be triggered by the poller
+        // Call the cacheUpdator twice, because it skips on the first iteration.
+        cacheUpdator.call(null, null);
+        cacheUpdator.call(null, null);
+
+        // Verify that reauthentication was triggered due to the token missing
         System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
     }
 

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -369,8 +369,6 @@ private class FFClientTest {
         FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
                                     .cache(new FFMockCache()).build();
 
-
-
         List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
         List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
         FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -24,7 +24,7 @@ private class FFClientTest {
         private FFModels.AuthInfo mockAuthInfo;
         private Long mockLastAuthTime;
         public Boolean authenticateCalled = false;
-        public Boolean simulateEvictedAuthToken;
+        public Boolean simulateEvictedAuthToken = false;
     
         public MockFFAuthService(FFModels.AuthInfo mockAuthInfo) {
             this.mockAuthInfo = mockAuthInfo;
@@ -310,6 +310,36 @@ private class FFClientTest {
 
         List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
         List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+        // Instantiate FFClient with the mock auth service
+        FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
+
+        // Instantiate the CacheUpdator with the FFClient instance
+        FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
+
+        // Directly invoke the logic that would be triggered by the poller
+        // Call the cacheUpdator twice, because it skips on the first iteration.
+        cacheUpdator.call(null, null);
+        cacheUpdator.call(null, null);
+
+        // Verify that reauthentication was triggered due to the token missing
+        System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
+    }
+
+    @isTest
+    private static void shouldReauthenticateWhenLastAuthTimeIsMissing() {
+        // Create mock authentication information
+        FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
+        MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
+
+        // Don't set the last auth time in order to simulate a cache eviction, just create client
+
+        // Create the FFClient configuration with a specified expiration interval
+        FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60) // Token expires after 24 hours
+                                    .cache(new FFMockCache()).build();
+
+        List<FFModelsFeatures.FeatureConfig> features = new List<FFModelsFeatures.FeatureConfig>();
+        List<FFModelsFeatures.TargetSegment> targets = new List<FFModelsFeatures.TargetSegment>();
+
         // Instantiate FFClient with the mock auth service
         FFClient client = new FFClient(mockAuthService, mockApi(features, targets), mockMetricsApi(features, targets), config, 'test', 'test');
 

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -247,29 +247,6 @@ private class FFClientTest {
         System.assertEquals(false, client.boolVariation('test-feature', target, true));
     }
 
-    // @isTest
-    // private static void shouldReauthenticateWhenTokenIsAboutToExpire() {
-    //     FFModels.AuthInfo mockAuthInfo = new FFModels.AuthInfo('mockToken', 'envUUID', 'cluster');
-    //     MockFFAuthService mockAuthService = new MockFFAuthService(mockAuthInfo);
-
-    //     // Set the last authentication time to be just over 23 hours ago
-    //     Long pastTimeMillis = Datetime.now().addSeconds(-((23 * 60 * 60) + 1)).getTime();
-    //     mockAuthService.setLastAuthTime(new FFModels.LastAuthTime(String.valueOf(pastTimeMillis)));
-
-    //     FFConfig config = FFConfig.builder().authExpireAfter(24 * 60 * 60).cache(new FFMockCache()).build();
-    //     FFClient client = new FFClient(mockAuthService, null, null, config, 'test', 'test');
-
-    //     new FFPoller(new FFClient.CacheUpdator(client))
-    //     .staticDelay(1)
-    //     .untilTrue(new FFClientBuilder.AlwaysFalse())
-    //     .execute();
-    
-
-
-    //     // Verify that reauthentication was triggered
-    //     System.assertEquals(true, mockAuthService.authenticateCalled, 'Reauthentication was not triggered as expected');
-    // }
-
     @isTest
     private static void shouldReauthenticateWhenTokenIsAboutToExpire() {
         // Create mock authentication information

--- a/force-app/test/FFClientTest.cls
+++ b/force-app/test/FFClientTest.cls
@@ -37,6 +37,10 @@ private class FFClientTest {
         public Long getLastAuthTime() {
             return mockLastAuthTime;
         }
+
+        public Boolean isAuthTokenPresent() {
+            return true;
+        }
     
         public void setLastAuthTime(Long lastAuthTime) {
             this.mockLastAuthTime = lastAuthTime;
@@ -273,7 +277,8 @@ private class FFClientTest {
         FFClient.CacheUpdator cacheUpdator = new FFClient.CacheUpdator(client);
 
         // Directly invoke the logic that would be triggered by the poller
-        // This should check the last authentication time and decide whether to reauthenticate
+        // Call the cacheUpdator twice, because it skips on the first iteration.
+        cacheUpdator.call(null, null);
         cacheUpdator.call(null, null);
 
         // Verify that reauthentication was triggered due to the token being near expiration

--- a/force-app/test/FFMockCache.cls
+++ b/force-app/test/FFMockCache.cls
@@ -30,7 +30,7 @@ public class FFMockCache implements FFCache {
     }
 
     public Map<String, String> getKey(String key) {
-        return (Map<String, String>) this.cache.get('auth'+key);
+        return (Map<String, String>) this.cache.get(key);
     }
 
     public String getCacheNamespace() { return 'TEST'; }

--- a/force-app/test/FFMockCache.cls
+++ b/force-app/test/FFMockCache.cls
@@ -16,6 +16,10 @@ public class FFMockCache implements FFCache {
         this.cache.put('auth'+key, authData);
     }
 
+    public void deleteAuth(String key) {
+        this.cache.remove('auth'+key);
+    } 
+
 
     public void putLastAuthTimeWithoutTTL(String key, Long lastAuthTime) {
         this.cache.put('lastAuth'+key, lastAuthTime);

--- a/force-app/test/FFMockCache.cls
+++ b/force-app/test/FFMockCache.cls
@@ -17,7 +17,7 @@ public class FFMockCache implements FFCache {
     }
 
 
-    public void putLastAuthTimeWithoutTTL(String key, String lastAuthTime) {
+    public void putLastAuthTimeWithoutTTL(String key, Long lastAuthTime) {
         this.cache.put('lastAuth'+key, lastAuthTime);
     }
 
@@ -33,8 +33,8 @@ public class FFMockCache implements FFCache {
         return (Map<String, String>) this.cache.get(key);
     }
 
-    public String getLastAuthKey(String key) {
-        return (String) this.cache.get(key);
+    public Long getLastAuthKey(String key) {
+        return (Long) this.cache.get(key);
     }
 
     public String getCacheNamespace() { return 'TEST'; }

--- a/force-app/test/FFMockCache.cls
+++ b/force-app/test/FFMockCache.cls
@@ -16,6 +16,11 @@ public class FFMockCache implements FFCache {
         this.cache.put('auth'+key, authData);
     }
 
+
+    public void putLastAuthTimeWithoutTTL(String key, Map<String, String> lastAuthTime) {
+        this.cache.put('lastAuth'+key, lastAuthTime);
+    }
+
     public List<FFModelsFeatures.FeatureConfig> getFeatures() {
         return (List<FFModelsFeatures.FeatureConfig>) this.cache.get('features');
     }
@@ -24,7 +29,7 @@ public class FFMockCache implements FFCache {
         return (List<FFModelsFeatures.TargetSegment>) this.cache.get('segments');
     }
 
-    public Map<String, String> getAuth(String key) {
+    public Map<String, String> getKey(String key) {
         return (Map<String, String>) this.cache.get('auth'+key);
     }
 

--- a/force-app/test/FFMockCache.cls
+++ b/force-app/test/FFMockCache.cls
@@ -17,7 +17,7 @@ public class FFMockCache implements FFCache {
     }
 
 
-    public void putLastAuthTimeWithoutTTL(String key, Map<String, String> lastAuthTime) {
+    public void putLastAuthTimeWithoutTTL(String key, String lastAuthTime) {
         this.cache.put('lastAuth'+key, lastAuthTime);
     }
 
@@ -31,6 +31,10 @@ public class FFMockCache implements FFCache {
 
     public Map<String, String> getKey(String key) {
         return (Map<String, String>) this.cache.get(key);
+    }
+
+    public String getLastAuthKey(String key) {
+        return (String) this.cache.get(key);
     }
 
     public String getCacheNamespace() { return 'TEST'; }


### PR DESCRIPTION
# What
1. Adds a mechanism for the Poller job to re-authenticate before the token expires in the Platform Cache. A margin of one hour is used before token expiration. 
This is achieved by adding a new `lastAuthTime` item to the cache, which Poller instances can all refer to for a global understanding on when they should refresh the auth token. 

2. The SDK wouldn’t fetch flags/groups unless Polling is enabled, and Polling must be explicitly enabled. This causes two issues: 1) Client init is basically async only, so immediate evaluations will get the default until a poller instance can update the cache. 2) If polling is not enabled, then the SDK won’t ever get flags and the default will always be returned.
This adds an optional `waitForInitialzed` option which adds a sync mode, and allows the SDK to fetch flags if polling is disabled. This WON'T work in a scheduled job as it will crash the job, so I've added warning to the readme.


# Why
1. Scheduled jobs that start up a client instance will try to authenticate if the SDK cannot find a token in the Platform Cache (which has a default TTL of 24 hours). The job fail with a `System Exception`  because scheduled jobs are not able to make external callouts. A customer is hitting this issue during quiet periods, when the Platform Cache has not been refreshed by client instances started up outside of scheduled jobs.

2. Align with other SDKs in offering a sync option, plus the SDK should fetch initial values even if polling is not enabled

# Testing 
- Unit tests for `CacheUpdator` 
- Manual - lastAuthTime gets created in the cache.
- Set token TTL to 1 minute, and started up a scheduled job to create a new client and evaluate. The scheduled job does not fail




